### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,10 @@
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/test/**/*",
@@ -17,7 +20,10 @@
       "!{projectRoot}/**/*.spec.ts",
       "!{projectRoot}/vitest.config.ts"
     ],
-    "sharedGlobals": ["{workspaceRoot}/tsconfig.base.json", "{workspaceRoot}/biome.json"]
+    "sharedGlobals": [
+      "{workspaceRoot}/tsconfig.base.json",
+      "{workspaceRoot}/biome.json"
+    ]
   },
   "nxCloudAccessToken": "",
   "plugins": [
@@ -33,7 +39,9 @@
         "file": "CHANGELOG.md"
       }
     },
-    "projects": ["packages/ts/*"],
+    "projects": [
+      "packages/ts/*"
+    ],
     "projectsRelationship": "independent",
     "version": {
       "conventionalCommits": true,
@@ -52,45 +60,80 @@
         "default",
         "{workspaceRoot}/biome.json",
         {
-          "externalDependencies": ["@biomejs/biome"]
+          "externalDependencies": [
+            "@biomejs/biome"
+          ]
         }
       ]
     },
     "build": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/dist"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ],
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
     },
     "check:exports": {
       "cache": true,
-      "dependsOn": ["build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
     "check:publint": {
       "cache": true,
-      "dependsOn": ["build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
     "check:size": {
       "cache": true,
-      "dependsOn": ["build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
     "nx-release-publish": {
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "options": {
         "packageRoot": "{projectRoot}"
       }
     },
     "test": {
       "cache": true,
-      "inputs": ["default", "^production"]
+      "inputs": [
+        "default",
+        "^production"
+      ]
     },
     "typecheck": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ]
     }
-  }
+  },
+  "nxCloudId": "6a07a03e8a73063a9eda9bf3"
 }

--- a/nx.json
+++ b/nx.json
@@ -9,10 +9,7 @@
     }
   },
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/test/**/*",
@@ -20,12 +17,10 @@
       "!{projectRoot}/**/*.spec.ts",
       "!{projectRoot}/vitest.config.ts"
     ],
-    "sharedGlobals": [
-      "{workspaceRoot}/tsconfig.base.json",
-      "{workspaceRoot}/biome.json"
-    ]
+    "sharedGlobals": ["{workspaceRoot}/tsconfig.base.json", "{workspaceRoot}/biome.json"]
   },
   "nxCloudAccessToken": "",
+  "nxCloudId": "6a07a03e8a73063a9eda9bf3",
   "plugins": [
     {
       "plugin": "./tools/nx-plugins/biome-inferred"
@@ -39,9 +34,7 @@
         "file": "CHANGELOG.md"
       }
     },
-    "projects": [
-      "packages/ts/*"
-    ],
+    "projects": ["packages/ts/*"],
     "projectsRelationship": "independent",
     "version": {
       "conventionalCommits": true,
@@ -60,80 +53,45 @@
         "default",
         "{workspaceRoot}/biome.json",
         {
-          "externalDependencies": [
-            "@biomejs/biome"
-          ]
+          "externalDependencies": ["@biomejs/biome"]
         }
       ]
     },
     "build": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
-      "outputs": [
-        "{projectRoot}/dist"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/dist"]
     },
     "check:exports": {
       "cache": true,
-      "dependsOn": [
-        "build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"]
     },
     "check:publint": {
       "cache": true,
-      "dependsOn": [
-        "build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"]
     },
     "check:size": {
       "cache": true,
-      "dependsOn": [
-        "build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"]
     },
     "nx-release-publish": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "options": {
         "packageRoot": "{projectRoot}"
       }
     },
     "test": {
       "cache": true,
-      "inputs": [
-        "default",
-        "^production"
-      ]
+      "inputs": ["default", "^production"]
     },
     "typecheck": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "default",
-        "^production"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production"]
     }
-  },
-  "nxCloudId": "6a07a03e8a73063a9eda9bf3"
+  }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6a07a03d8a73063a9eda9bee/workspaces/6a07a03e8a73063a9eda9bf3

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.