### PR TITLE
chore(deps): upgrade Rust deps — pairing_ce 0.28, ff_ce 0.14, getrandom 0.4, neon 1.x migration

### DIFF
--- a/apps/scanner/src/types/cytoscape-fcose.d.ts
+++ b/apps/scanner/src/types/cytoscape-fcose.d.ts
@@ -1,5 +1,6 @@
 declare module 'cytoscape-fcose' {
   import type cytoscape from 'cytoscape';
+
   const fcose: cytoscape.Ext;
   export default fcose;
 }

--- a/packages/jvm/groth16/Cargo.lock
+++ b/packages/jvm/groth16/Cargo.lock
@@ -82,15 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-vec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,28 +177,30 @@ dependencies = [
 
 [[package]]
 name = "ff_ce"
-version = "0.7.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18af1ea1b80a4b474fae13af4c58cf0a5a2bc33832d5fa70f68a4b286178fdb5"
+checksum = "5b538e4231443a5b9c507caee3356f016d832cf7393d2d90f03ea3180d4e3fbc"
 dependencies = [
  "byteorder",
  "ff_derive_ce",
- "hex",
+ "hex 0.4.3",
  "rand 0.4.6",
+ "serde",
 ]
 
 [[package]]
 name = "ff_derive_ce"
-version = "0.5.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d245b4e76c5b36bb7721ea15b7fbc61bebf0c5d2890eaf49fe1e2a3eed36db9"
+checksum = "b96fbccd88dbb1fac4ee4a07c2fcc4ca719a74ffbd9d2b9d41d8c8eb073d8b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.14.9",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -308,7 +301,6 @@ dependencies = [
  "groth16_primitives",
  "lazy_static",
  "neon",
- "neon-build",
  "pairing",
  "phase2",
  "rand 0.4.6",
@@ -322,7 +314,6 @@ dependencies = [
  "arrayvec 0.5.2",
  "base64",
  "bellman",
- "bincode",
  "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
  "byteorder",
  "itertools",
@@ -341,7 +332,7 @@ dependencies = [
  "bellman",
  "blake2-rfc 0.2.18 (git+https://github.com/gtank/blake2-rfc?rev=7a5b5fc99ae483a0043db7547fb79a6fa44b88a9)",
  "groth16_circuit",
- "hex",
+ "hex 0.3.2",
  "pairing",
  "phase2",
  "rand 0.4.6",
@@ -359,6 +350,12 @@ name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
@@ -426,7 +423,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote 1.0.45",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -467,8 +464,8 @@ version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -511,19 +508,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "neon-build"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bac98a702e71804af3dacfde41edde4a16076a7bbe889ae61e56e18c5b1c811"
-
-[[package]]
 name = "neon-macros"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39e43767817fc963f90f400600967a2b2403602c6440685d09a6bc4e02b70b1"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -539,7 +530,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -554,6 +545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
  "num-integer",
  "num-traits",
 ]
@@ -595,7 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -646,13 +647,15 @@ dependencies = [
 
 [[package]]
 name = "pairing_ce"
-version = "0.18.0"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f075a9c570e2026111cb6dddf6a320e5163c42aa32500b315ec34acbcf7c9b36"
+checksum = "843b5b6fb63f00460f611dbc87a50bbbb745f0dfe5cbf67ca89299c79098640e"
 dependencies = [
  "byteorder",
+ "cfg-if",
  "ff_ce",
  "rand 0.4.6",
+ "serde",
 ]
 
 [[package]]
@@ -687,15 +690,6 @@ checksum = "7be55bf0ae1635f4d7c7ddd6efc05c631e98a82104a73d35550bbc52db960027"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
@@ -705,20 +699,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
- "proc-macro2 1.0.106",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -853,8 +838,8 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -866,13 +851,13 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
-version = "0.14.9"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -881,8 +866,8 @@ version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -902,8 +887,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -913,8 +898,8 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
  "test-case-core",
 ]
@@ -941,12 +926,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unreachable"

--- a/packages/jvm/groth16/groth16_jni/Cargo.toml
+++ b/packages/jvm/groth16/groth16_jni/Cargo.toml
@@ -17,7 +17,7 @@ bellman = { version = "0.1.0" }
 groth16_primitives = { path = "../groth16_primitives"}
 sapling-crypto = { path = "../sapling-crypto" }
 pairing = "0.14"
-pairing_ce = "0.18" # for bn256
+pairing_ce = "0.28" # for bn256
 num = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 base64 = "0.11.0"
@@ -27,7 +27,7 @@ rand = "0.4"
 
 # for bn256
 [dependencies.ff]
-version = "=0.7"
+version = "0.14"
 features = ["derive"]
 package = "ff_ce"
 

--- a/packages/jvm/groth16/groth16_node/native/Cargo.toml
+++ b/packages/jvm/groth16/groth16_node/native/Cargo.toml
@@ -3,15 +3,11 @@ name = "groth16_node"
 version = "0.1.0"
 authors = ["Igor Gulamov <igor.gulamov@gmail.com>"]
 license = "MIT"
-build = "build.rs"
 exclude = ["artifacts.json", "index.node"]
 
 [lib]
 name = "groth16_node"
 crate-type = ["cdylib"]
-
-[build-dependencies]
-neon-build = "0.10.1"
 
 [dependencies]
 neon = "1.1.1"

--- a/packages/jvm/groth16/groth16_node/native/build.rs
+++ b/packages/jvm/groth16/groth16_node/native/build.rs
@@ -1,7 +1,1 @@
-extern crate neon_build;
-
-fn main() {
-    neon_build::setup(); // must be called in build.rs
-
-    // add project-specific build logic here...
-}
+fn main() {}

--- a/packages/jvm/groth16/groth16_node/native/src/helpers.rs
+++ b/packages/jvm/groth16/groth16_node/native/src/helpers.rs
@@ -1,41 +1,22 @@
+use lazy_static::lazy_static;
 use neon::prelude::*;
-use neon::types::Value;
-use pairing::bls12_381::{Fr, Bls12};
+use neon::types::buffer::TypedArray;
+use pairing::bls12_381::{Bls12, Fr};
 use pairing::{Field, PrimeField, PrimeFieldRepr};
 
-use rand::os::OsRng;
-use rand::Rng;
-
-
-use std::mem::transmute;
 use std::io::Cursor;
 
-
-use bellman::{Circuit, ConstraintSystem, SynthesisError};
-use sapling_crypto::jubjub::{JubjubEngine, JubjubParams, JubjubBls12};
-use sapling_crypto::pedersen_hash::{Personalization};
-use sapling_crypto::circuit::{pedersen_hash};
-use sapling_crypto::circuit::num::{AllocatedNum, Num};
-use bellman::groth16::{Proof, generate_random_parameters, prepare_verifying_key, create_random_proof, verify_proof};
-use groth16_circuit::circuit::{Transfer, MERKLE_PROOF_LEN};
-use groth16_primitives::transactions::NoteData;
-use groth16_primitives::fieldtools::fr_to_repr_bool;
+use bellman::groth16::Proof;
+use groth16_circuit::circuit::Transfer;
 use groth16_primitives::serialization::read_fr_repr_be;
+use groth16_primitives::transactions::NoteData;
 use arrayvec::ArrayVec;
 
 use groth16_primitives::verifier;
-
-
+use sapling_crypto::jubjub::JubjubBls12;
 
 lazy_static! {
-    pub static ref JUBJUB_PARAMS : JubjubBls12 = JubjubBls12::new();
-}
-
-
-pub fn buf_copy_from_slice(cx: &FunctionContext, source: &[u8], buf: &mut Handle<JsBuffer>) {
-    cx.borrow_mut(buf, |data| {
-        data.as_mut_slice().copy_from_slice(source);
-    });
+    pub static ref JUBJUB_PARAMS: JubjubBls12 = JubjubBls12::new();
 }
 
 pub fn read_obj_fr(cx: &mut FunctionContext, obj: Handle<JsObject>, key: &str) -> NeonResult<Fr> {
@@ -44,63 +25,69 @@ pub fn read_obj_fr(cx: &mut FunctionContext, obj: Handle<JsObject>, key: &str) -
 }
 
 pub fn read_val_fr(cx: &mut FunctionContext, val: Handle<JsValue>) -> NeonResult<Fr> {
-    let buff_field = val.downcast::<JsBuffer>().or_else(|_| cx.throw_error("could not downcast value to Buffer"))?;
-    let buff_field_slice = cx.borrow(&buff_field, |data| data.as_slice());
-    let repr = read_fr_repr_be::<Fr>(buff_field_slice).or_else(|_| cx.throw_error("Buffer must be uint256 BE number"))?;
+    let buff_field = val
+        .downcast::<JsBuffer, _>(cx)
+        .or_else(|_| cx.throw_error("could not downcast value to Buffer"))?;
+    let repr = {
+        let slice = buff_field.as_slice(cx);
+        read_fr_repr_be::<Fr>(slice)
+    }
+    .or_else(|_| cx.throw_error("Buffer must be uint256 BE number"))?;
     Fr::from_repr(repr).or_else(|_| cx.throw_error("Wrong field element"))
 }
-
 
 pub fn read_buf_fr(cx: &mut FunctionContext, buff_field: Handle<JsBuffer>) -> NeonResult<Fr> {
-    let buff_field_slice = cx.borrow(&buff_field, |data| data.as_slice());
-    let repr = read_fr_repr_be::<Fr>(buff_field_slice).or_else(|_| cx.throw_error("Buffer must be uint256 BE number"))?;
+    let repr = {
+        let slice = buff_field.as_slice(cx);
+        read_fr_repr_be::<Fr>(slice)
+    }
+    .or_else(|_| cx.throw_error("Buffer must be uint256 BE number"))?;
     Fr::from_repr(repr).or_else(|_| cx.throw_error("Wrong field element"))
 }
 
-pub fn parse_note_data(cx: &mut FunctionContext, note_obj:Handle<JsObject>) -> NeonResult<NoteData<Bls12>> {
+pub fn parse_note_data(cx: &mut FunctionContext, note_obj: Handle<JsObject>) -> NeonResult<NoteData<Bls12>> {
     Ok(NoteData::<Bls12> {
         asset_id: read_obj_fr(cx, note_obj, "asset_id")?,
         amount: read_obj_fr(cx, note_obj, "amount")?,
         native_amount: read_obj_fr(cx, note_obj, "native_amount")?,
         txid: read_obj_fr(cx, note_obj, "txid")?,
-        owner: read_obj_fr(cx, note_obj, "owner")?
+        owner: read_obj_fr(cx, note_obj, "owner")?,
     })
 }
 
 pub fn fr_to_js<'a>(cx: &mut FunctionContext<'a>, fr: &Fr) -> JsResult<'a, JsBuffer> {
     let mut buff = Cursor::new(Vec::<u8>::new());
     fr.into_repr().write_be(&mut buff).unwrap();
-
-    let mut hash_js_buf = JsBuffer::new(cx, buff.get_ref().len() as u32)?;
-    buf_copy_from_slice(cx, buff.get_ref(), &mut hash_js_buf);
-    Ok(hash_js_buf)
+    JsBuffer::from_slice(cx, buff.get_ref())
 }
 
 pub fn proof_to_js<'a>(cx: &mut FunctionContext<'a>, proof: &Proof<Bls12>) -> JsResult<'a, JsBuffer> {
     let mut proof_cur = Cursor::new(Vec::<u8>::new());
     proof.write(&mut proof_cur).unwrap();
-    let mut proof_js_buf = JsBuffer::new(cx, proof_cur.get_ref().len() as u32)?;
-    buf_copy_from_slice(cx, proof_cur.get_ref(), &mut proof_js_buf);
-    Ok(proof_js_buf)
+    JsBuffer::from_slice(cx, proof_cur.get_ref())
 }
 
 pub fn verifier_to_js<'a>(cx: &mut FunctionContext<'a>, verifier: &verifier::TruncatedVerifyingKey<Bls12>) -> JsResult<'a, JsBuffer> {
     let mut verifier_cur = Cursor::new(Vec::<u8>::new());
     verifier.write(&mut verifier_cur).unwrap();
-    let mut verifier_js_buf = JsBuffer::new(cx, verifier_cur.get_ref().len() as u32)?;
-    buf_copy_from_slice(cx, verifier_cur.get_ref(), &mut verifier_js_buf);
-    Ok(verifier_js_buf)
+    JsBuffer::from_slice(cx, verifier_cur.get_ref())
 }
 
-pub fn parse_pair<'a, U:Value>(cx: &mut FunctionContext<'a>, value:Handle<'a, JsValue>) -> NeonResult<[Handle<'a, U>;2]> {
-    let value = value.downcast::<JsArray>()
+pub fn parse_pair<'a, U: Value>(cx: &mut FunctionContext<'a>, value: Handle<'a, JsValue>) -> NeonResult<[Handle<'a, U>; 2]> {
+    let value = value
+        .downcast::<JsArray, _>(cx)
         .or_else(|_| cx.throw_error("Could not downcast value to Array"))?
         .to_vec(cx)?;
-    if value.len()!= 2 {
+    if value.len() != 2 {
         return cx.throw_error("in_note length should be 2");
     }
 
-    let value = value.into_iter().map(|item| item.downcast::<U>().or_else(|_| cx.throw_error("downcast pair item error")))
-        .collect::<NeonResult<ArrayVec<[Handle<'a, U>;2]>>>()?.into_inner().or_else(|_| cx.throw_error("Array was not completely filled"))?;
-    Ok(value)
+    let value = value
+        .into_iter()
+        .map(|item| item.downcast::<U, _>(cx).or_else(|_| cx.throw_error("downcast pair item error")))
+        .collect::<NeonResult<ArrayVec<[Handle<'a, U>; 2]>>>()?;
+    match value.into_inner() {
+        Ok(arr) => Ok(arr),
+        Err(_) => cx.throw_error("Array was not completely filled"),
+    }
 }

--- a/packages/jvm/groth16/groth16_node/native/src/lib.rs
+++ b/packages/jvm/groth16/groth16_node/native/src/lib.rs
@@ -1,50 +1,34 @@
-#[macro_use] extern crate neon;
-#[macro_use] extern crate lazy_static;
-extern crate arrayvec;
-extern crate pairing;
-extern crate sapling_crypto;
-extern crate bellman;
-extern crate groth16_circuit;
-extern crate groth16_primitives;
-extern crate phase2;
-extern crate rand;
-
 pub mod helpers;
 
 use neon::prelude::*;
+use neon::types::buffer::TypedArray;
 
-use pairing::bls12_381::{Fr, Bls12};
+use pairing::bls12_381::{Bls12, Fr};
 use pairing::{Field, PrimeField, PrimeFieldRepr};
 
 use rand::os::OsRng;
 use rand::Rng;
 
-
-use std::mem::transmute;
 use std::io::Cursor;
 
-
-use bellman::{Circuit, ConstraintSystem, SynthesisError};
-use sapling_crypto::jubjub::{JubjubEngine, JubjubParams, JubjubBls12};
-use sapling_crypto::pedersen_hash::{Personalization};
-use sapling_crypto::circuit::{pedersen_hash};
-use sapling_crypto::circuit::num::{AllocatedNum, Num};
-use bellman::groth16::{Proof, generate_random_parameters, prepare_verifying_key, create_random_proof, verify_proof};
-use groth16_circuit::circuit::{Transfer, MERKLE_PROOF_LEN, UtxoAccumulator};
-use groth16_primitives::transactions::NoteData;
+use bellman::groth16::{create_random_proof, Proof};
+use groth16_circuit::circuit::{Transfer, UtxoAccumulator, MERKLE_PROOF_LEN};
 use groth16_primitives::fieldtools::fr_to_repr_bool;
 use groth16_primitives::serialization::read_fr_repr_be;
+use groth16_primitives::transactions::NoteData;
 use groth16_primitives::verifier;
 use arrayvec::ArrayVec;
+use sapling_crypto::pedersen_hash::Personalization;
 
 use crate::helpers::*;
 
 
 pub fn extract_vk(mut cx: FunctionContext) -> JsResult<JsBuffer> {
-    let mpc_params_buff : Handle<JsBuffer> = cx.argument(0)?;
-    let mpc_params_slice = cx.borrow(&mpc_params_buff, |data| data.as_slice());
-
-    let params = phase2::MPCParameters::read(mpc_params_slice, false).unwrap();
+    let mpc_params_buff: Handle<JsBuffer> = cx.argument(0)?;
+    let params = {
+        let slice = mpc_params_buff.as_slice(&cx);
+        phase2::MPCParameters::read(slice, false).unwrap()
+    };
     let groth16_params = params.get_params();
     let tvk = verifier::truncate_verifying_key(&groth16_params.vk);
     verifier_to_js(&mut cx, &tvk)
@@ -52,110 +36,135 @@ pub fn extract_vk(mut cx: FunctionContext) -> JsResult<JsBuffer> {
 
 
 pub fn verify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
-    let verifier_buff : Handle<JsBuffer> = cx.argument(0)?;
-    let verifier_slice = cx.borrow(&verifier_buff, |data| data.as_slice());
+    let verifier_buff: Handle<JsBuffer> = cx.argument(0)?;
+    let tvk = {
+        let slice = verifier_buff.as_slice(&cx);
+        verifier::TruncatedVerifyingKey::<Bls12>::read(slice).unwrap()
+    };
 
-    let tvk = verifier::TruncatedVerifyingKey::<Bls12>::read(verifier_slice).unwrap();
+    let proof_buff: Handle<JsBuffer> = cx.argument(1)?;
+    let proof = {
+        let slice = proof_buff.as_slice(&cx);
+        Proof::<Bls12>::read(slice).or_else(|_| cx.throw_error("Wrong proof format"))?
+    };
 
-    let proof_buff : Handle<JsBuffer> = cx.argument(1)?;
-    let proof_buff_slice = cx.borrow(&proof_buff, |data| data.as_slice());
-
-    let proof = Proof::<Bls12>::read(proof_buff_slice).or_else(|_| cx.throw_error("Wrong proof format"))?;
-
-    let public_inputs : Handle<JsArray> = cx.argument(2)?;
+    let public_inputs: Handle<JsArray> = cx.argument(2)?;
     let public_inputs = public_inputs.to_vec(&mut cx)?;
-    let public_inputs = public_inputs.iter().map(|&x| read_val_fr(&mut cx, x)).collect::<NeonResult<Vec<Fr>>>()?;
+    let public_inputs = public_inputs
+        .iter()
+        .map(|&x| read_val_fr(&mut cx, x))
+        .collect::<NeonResult<Vec<Fr>>>()?;
 
-    let res = verifier::verify_proof(&tvk, &proof, &public_inputs).or_else(|_| cx.throw_error("Error during proof verification"))?;
-    Ok(JsBoolean::new(&mut cx, res))
-
+    let res = verifier::verify_proof(&tvk, &proof, &public_inputs)
+        .or_else(|_| cx.throw_error("Error during proof verification"))?;
+    Ok(cx.boolean(res))
 }
 
 
-
-pub fn note_hash(mut cx: FunctionContext) ->JsResult<JsBuffer> {
-    let note_obj : Handle<JsObject> = cx.argument(0)?;
+pub fn note_hash(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+    let note_obj: Handle<JsObject> = cx.argument(0)?;
     let note = parse_note_data(&mut cx, note_obj)?;
-    
     let hash = groth16_primitives::transactions::note_hash(&note, &JUBJUB_PARAMS);
     fr_to_js(&mut cx, &hash)
 }
 
-pub fn nullifier(mut cx: FunctionContext) ->JsResult<JsBuffer> {
-    let note_hash : Handle<JsBuffer> = cx.argument(0)?;
+pub fn nullifier(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+    let note_hash: Handle<JsBuffer> = cx.argument(0)?;
     let note_hash = read_buf_fr(&mut cx, note_hash)?;
-    let sk : Handle<JsBuffer> = cx.argument(1)?;
+    let sk: Handle<JsBuffer> = cx.argument(1)?;
     let sk = read_buf_fr(&mut cx, sk)?;
     let nf = groth16_primitives::transactions::nullifier::<Bls12>(&note_hash, &sk, &JUBJUB_PARAMS);
     fr_to_js(&mut cx, &nf)
 }
 
-pub fn pubkey(mut cx: FunctionContext) ->JsResult<JsBuffer> {
-    let sk : Handle<JsBuffer> = cx.argument(0)?;
+pub fn pubkey(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+    let sk: Handle<JsBuffer> = cx.argument(0)?;
     let sk = read_buf_fr(&mut cx, sk)?;
     let nf = groth16_primitives::transactions::pubkey::<Bls12>(&sk, &JUBJUB_PARAMS);
     fr_to_js(&mut cx, &nf)
 }
 
-pub fn edh(mut cx: FunctionContext) ->JsResult<JsBuffer> {
-    let pk : Handle<JsBuffer> = cx.argument(0)?;
+pub fn edh(mut cx: FunctionContext) -> JsResult<JsBuffer> {
+    let pk: Handle<JsBuffer> = cx.argument(0)?;
     let pk = read_buf_fr(&mut cx, pk)?;
-    let sk : Handle<JsBuffer> = cx.argument(1)?;
+    let sk: Handle<JsBuffer> = cx.argument(1)?;
     let sk = read_buf_fr(&mut cx, sk)?;
-    let nf = groth16_primitives::transactions::edh::<Bls12>(&pk, &sk, &JUBJUB_PARAMS).ok_or(()).or_else(|_| cx.throw_error("Not an elliptic curve point"))?;
+    let nf = groth16_primitives::transactions::edh::<Bls12>(&pk, &sk, &JUBJUB_PARAMS)
+        .ok_or(())
+        .or_else(|_| cx.throw_error("Not an elliptic curve point"))?;
     fr_to_js(&mut cx, &nf)
 }
 
 
-
-
-
-pub fn parse_transfer(cx: &mut FunctionContext, transfer_obj:Handle<JsObject>) -> NeonResult<Transfer<'static, Bls12>> {
-
+pub fn parse_transfer(cx: &mut FunctionContext, transfer_obj: Handle<JsObject>) -> NeonResult<Transfer<'static, Bls12>> {
     let in_note = transfer_obj.get(cx, "in_note")?;
     let in_note = parse_pair::<JsObject>(cx, in_note)?;
-    let in_note = in_note.iter().map(|&item| {
-        parse_note_data(cx, item).map(|e| Some(e))
-    }).collect::<NeonResult<ArrayVec<[Option<NoteData<Bls12>>;2]>>>()?.into_inner().or_else(|_| cx.throw_error("Could not parse in_note"))?;
-    
-    
+    let in_note = match in_note
+        .iter()
+        .map(|&item| parse_note_data(cx, item).map(Some))
+        .collect::<NeonResult<ArrayVec<[Option<NoteData<Bls12>>; 2]>>>()?
+        .into_inner()
+    {
+        Ok(arr) => arr,
+        Err(_) => return cx.throw_error("Could not parse in_note"),
+    };
 
     let out_note = transfer_obj.get(cx, "out_note")?;
     let out_note = parse_pair::<JsObject>(cx, out_note)?;
-    let out_note = out_note.iter().map(|&item| {
-        parse_note_data(cx, item).map(|e| Some(e))
-    }).collect::<NeonResult<ArrayVec<[Option<NoteData<Bls12>>;2]>>>()?.into_inner().or_else(|_| cx.throw_error("Could not parse out_note"))?;
-    
+    let out_note = match out_note
+        .iter()
+        .map(|&item| parse_note_data(cx, item).map(Some))
+        .collect::<NeonResult<ArrayVec<[Option<NoteData<Bls12>>; 2]>>>()?
+        .into_inner()
+    {
+        Ok(arr) => arr,
+        Err(_) => return cx.throw_error("Could not parse out_note"),
+    };
 
     let in_index = transfer_obj.get(cx, "in_proof_index")?;
     let in_index = parse_pair::<JsBuffer>(cx, in_index)?;
-    let in_index = in_index.iter().map(|&item| {
-        read_buf_fr(cx, item)
-    }).collect::<NeonResult<ArrayVec<[Fr;2]>>>()?.into_inner().or_else(|_| cx.throw_error("Could not parse in_proof_index"))?;
-    
+    let in_index = match in_index
+        .iter()
+        .map(|&item| read_buf_fr(cx, item))
+        .collect::<NeonResult<ArrayVec<[Fr; 2]>>>()?
+        .into_inner()
+    {
+        Ok(arr) => arr,
+        Err(_) => return cx.throw_error("Could not parse in_proof_index"),
+    };
 
     let in_proof = transfer_obj.get(cx, "in_proof_sibling")?;
     let in_proof = parse_pair::<JsArray>(cx, in_proof)?;
 
-    let in_proof = in_proof.iter().zip(in_index.iter()).map(|(&item, &index)| {
-        let item = item.to_vec(cx)?;
-        if item.len() != MERKLE_PROOF_LEN {
-            return cx.throw_error(format!("Merkle proof length should be {}.", MERKLE_PROOF_LEN));
-        }
-
-        if fr_to_repr_bool::<Fr>(&index).into_iter().skip(MERKLE_PROOF_LEN).any(|e| e) {
-            return cx.throw_error("Index value should not be bigger than 2^MERKLE_PROOF_LEN");
-        }
-
-        let item = item.into_iter().zip(fr_to_repr_bool::<Fr>(&index)).map(|(e, b)| (read_val_fr(cx, e).unwrap(), b)).collect::<Vec<(Fr, bool)>>();
-        Ok(Some(item))
-    }).collect::<NeonResult<ArrayVec<[Option<Vec<(Fr, bool)>>;2]>>>()?.into_inner().or_else(|_| cx.throw_error("in_proof_sibling.length should be 2"))?;
+    let in_proof = match in_proof
+        .iter()
+        .zip(in_index.iter())
+        .map(|(&item, &index)| {
+            let item = item.to_vec(cx)?;
+            if item.len() != MERKLE_PROOF_LEN {
+                return cx.throw_error(format!("Merkle proof length should be {}.", MERKLE_PROOF_LEN));
+            }
+            if fr_to_repr_bool::<Fr>(&index).into_iter().skip(MERKLE_PROOF_LEN).any(|e| e) {
+                return cx.throw_error("Index value should not be bigger than 2^MERKLE_PROOF_LEN");
+            }
+            let item = item
+                .into_iter()
+                .zip(fr_to_repr_bool::<Fr>(&index))
+                .map(|(e, b)| (read_val_fr(cx, e).unwrap(), b))
+                .collect::<Vec<(Fr, bool)>>();
+            Ok(Some(item))
+        })
+        .collect::<NeonResult<ArrayVec<[Option<Vec<(Fr, bool)>>; 2]>>>()?
+        .into_inner()
+    {
+        Ok(arr) => arr,
+        Err(_) => return cx.throw_error("in_proof_sibling.length should be 2"),
+    };
 
     let root_hash = Some(read_obj_fr(cx, transfer_obj, "root_hash")?);
     let sk = Some(read_obj_fr(cx, transfer_obj, "sk")?);
     let packed_asset = Some(read_obj_fr(cx, transfer_obj, "packed_asset")?);
     let receiver = Some(read_obj_fr(cx, transfer_obj, "receiver")?);
-
 
     Ok(Transfer {
         receiver,
@@ -165,56 +174,72 @@ pub fn parse_transfer(cx: &mut FunctionContext, transfer_obj:Handle<JsObject>) -
         root_hash,
         sk,
         packed_asset,
-        params: &JUBJUB_PARAMS
+        params: &JUBJUB_PARAMS,
     })
 }
 
 
 pub fn transfer(mut cx: FunctionContext) -> JsResult<JsBuffer> {
     let mut rng = OsRng::new().unwrap();
-    let mpc_params_buff : Handle<JsBuffer> = cx.argument(0)?;
-    let mpc_params_slice = cx.borrow(&mpc_params_buff, |data| data.as_slice());
+    let mpc_params_buff: Handle<JsBuffer> = cx.argument(0)?;
+    let params = {
+        let slice = mpc_params_buff.as_slice(&cx);
+        phase2::MPCParameters::read(slice, false).or_else(|_| cx.throw_error("Could not read mpc params"))?
+    };
 
-    let transfer_obj : Handle<JsObject> = cx.argument(1)?;
-    let params = phase2::MPCParameters::read(mpc_params_slice, false).or_else(|_| cx.throw_error("Could not read mpc params"))?;
-
+    let transfer_obj: Handle<JsObject> = cx.argument(1)?;
     let c = parse_transfer(&mut cx, transfer_obj)?;
-    let proof = create_random_proof(c, params.get_params(), &mut rng).or_else(|_| cx.throw_error("Could not create proof"))?;
+    let proof = create_random_proof(c, params.get_params(), &mut rng)
+        .or_else(|_| cx.throw_error("Could not create proof"))?;
 
     proof_to_js(&mut cx, &proof)
 }
 
 
-pub fn parse_utxo_accumulator(cx: &mut FunctionContext, transfer_obj:Handle<JsObject>) -> NeonResult<UtxoAccumulator<'static, Bls12>> {
-
+pub fn parse_utxo_accumulator(cx: &mut FunctionContext, transfer_obj: Handle<JsObject>) -> NeonResult<UtxoAccumulator<'static, Bls12>> {
     let note_hashes = transfer_obj.get(cx, "note_hashes")?;
     let note_hashes = parse_pair::<JsBuffer>(cx, note_hashes)?;
-    let note_hashes = note_hashes.iter().map(|&item| {
-        read_buf_fr(cx, item).map(|e| Some(e))
-    }).collect::<NeonResult<ArrayVec<[Option<Fr>;2]>>>()?.into_inner().map_err(|_| neon::result::Throw )?;
+    let note_hashes = match note_hashes
+        .iter()
+        .map(|&item| read_buf_fr(cx, item).map(Some))
+        .collect::<NeonResult<ArrayVec<[Option<Fr>; 2]>>>()?
+        .into_inner()
+    {
+        Ok(arr) => arr,
+        Err(_) => return cx.throw_error("Could not fill note_hashes array"),
+    };
 
-    let index =  Some(read_obj_fr(cx, transfer_obj, "proof_index")?);
-   
+    let index = Some(read_obj_fr(cx, transfer_obj, "proof_index")?);
 
     let proof = transfer_obj.get(cx, "proof_sibling")?;
     let proof = parse_pair::<JsArray>(cx, proof)?;
 
-    let proof = proof.iter().map(|&item| {
-        let item = item.to_vec(cx)?;
-        if item.len() != MERKLE_PROOF_LEN-1 {
-            return cx.throw_error(format!("Merkle proof length should be {}.", MERKLE_PROOF_LEN-1));
-        }
-
-        let item = item.into_iter().map(|e| read_val_fr(cx, e)).collect::<NeonResult<Vec<_>>>()?;
-        Ok(Some(item))
-    }).collect::<NeonResult<ArrayVec<[Option<Vec<Fr>>;2]>>>()?.into_inner().or_else(|_| cx.throw_error("proof_sibling.length should be 2"))?;
+    let proof = match proof
+        .iter()
+        .map(|&item| {
+            let item = item.to_vec(cx)?;
+            if item.len() != MERKLE_PROOF_LEN - 1 {
+                return cx.throw_error(format!("Merkle proof length should be {}.", MERKLE_PROOF_LEN - 1));
+            }
+            let item = item
+                .into_iter()
+                .map(|e| read_val_fr(cx, e))
+                .collect::<NeonResult<Vec<_>>>()?;
+            Ok(Some(item))
+        })
+        .collect::<NeonResult<ArrayVec<[Option<Vec<Fr>>; 2]>>>()?
+        .into_inner()
+    {
+        Ok(arr) => arr,
+        Err(_) => return cx.throw_error("proof_sibling.length should be 2"),
+    };
 
     Ok(UtxoAccumulator {
-        note_hashes:note_hashes,
+        note_hashes,
         index,
         old_proof: proof[0].clone(),
         new_proof: proof[1].clone(),
-        params: &JUBJUB_PARAMS
+        params: &JUBJUB_PARAMS,
     })
 }
 
@@ -223,23 +248,29 @@ pub fn merkle_hash(mut cx: FunctionContext) -> JsResult<JsBuffer> {
     let left = read_buf_fr(&mut cx, left_handle)?;
     let right_handle = cx.argument::<JsBuffer>(1)?;
     let right = read_buf_fr(&mut cx, right_handle)?;
-    let n = cx.argument::<JsNumber>(2)?.value();
+    let n = cx.argument::<JsNumber>(2)?.value(&mut cx);
     if n.fract() != 0.0 {
         return cx.throw_error("3rd parameter should be integer");
     }
-    let hash = groth16_primitives::pedersen_hasher::compress::<Bls12>(&left, &right, Personalization::MerkleTree(n.round() as usize), &JUBJUB_PARAMS);
+    let hash = groth16_primitives::pedersen_hasher::compress::<Bls12>(
+        &left,
+        &right,
+        Personalization::MerkleTree(n.round() as usize),
+        &JUBJUB_PARAMS,
+    );
     fr_to_js(&mut cx, &hash)
 }
 
 
 pub fn utxo_accumulator(mut cx: FunctionContext) -> JsResult<JsBuffer> {
     let mut rng = OsRng::new().unwrap();
-    let mpc_params_buff : Handle<JsBuffer> = cx.argument(0)?;
-    let mpc_params_slice = cx.borrow(&mpc_params_buff, |data| data.as_slice());
+    let mpc_params_buff: Handle<JsBuffer> = cx.argument(0)?;
+    let params = {
+        let slice = mpc_params_buff.as_slice(&cx);
+        phase2::MPCParameters::read(slice, false).unwrap()
+    };
 
-    let acc_obj : Handle<JsObject> = cx.argument(1)?;
-    let params = phase2::MPCParameters::read(mpc_params_slice, false).unwrap();
-
+    let acc_obj: Handle<JsObject> = cx.argument(1)?;
     let c = parse_utxo_accumulator(&mut cx, acc_obj)?;
     let proof = create_random_proof(c, params.get_params(), &mut rng).unwrap();
 
@@ -247,15 +278,16 @@ pub fn utxo_accumulator(mut cx: FunctionContext) -> JsResult<JsBuffer> {
 }
 
 
-register_module!(mut cx, {
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("verify", verify)?;
-    cx.export_function("transfer", transfer)?;  
-    cx.export_function("extract_vk", extract_vk)?;  
-    cx.export_function("utxo_accumulator", utxo_accumulator)?;        
+    cx.export_function("transfer", transfer)?;
+    cx.export_function("extract_vk", extract_vk)?;
+    cx.export_function("utxo_accumulator", utxo_accumulator)?;
     cx.export_function("merkle_hash", merkle_hash)?;
     cx.export_function("nullifier", nullifier)?;
     cx.export_function("edh", edh)?;
     cx.export_function("pubkey", pubkey)?;
-    cx.export_function("note_hash", note_hash)
-    
-});
+    cx.export_function("note_hash", note_hash)?;
+    Ok(())
+}

--- a/packages/jvm/groth16/groth16_primitives/Cargo.toml
+++ b/packages/jvm/groth16/groth16_primitives/Cargo.toml
@@ -15,7 +15,6 @@ pairing = "0.14"
 num = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 base64 = "0.11.0"
-bincode = "1.2.0"
 byteorder = "1"
 itertools = "0.14.0"
 arrayvec = "0.5.1"

--- a/packages/sdk/crypto/Cargo.toml
+++ b/packages/sdk/crypto/Cargo.toml
@@ -21,5 +21,7 @@ wasm-opt = ['-Oz', '-c']
 argon2 = {version = "0.5.3", default-features = false, features = ["alloc"]}
 ed25519-axolotl = "1.7"
 ed25519-compact = {version = "2.0", features = ["opt_size", "traits", "x25519"]}
-getrandom = {version = "0.2", features = ["js"]}
+getrandom = {version = "0.4", features = ["wasm_js"]}
+# Also enable js feature for getrandom 0.2 transitive dependencies (argon2, rand_core, etc.)
+getrandom02 = {version = "0.2", features = ["js"], package = "getrandom"}
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Consolidates Dependabot PRs #10, #11, #12 with the required API migrations, plus the neon 1.x source migration required by the already-merged PR #15.

## Changes

### packages/jvm/groth16/groth16_primitives
- Remove unused `bincode` dependency

### packages/sdk/crypto
- Bump `getrandom` 0.2 → 0.4, rename feature `js` → `wasm_js`
- Add `getrandom02` compat alias (getrandom 0.2 + `js` feature) so transitive dependencies (argon2, rand_core) continue to work in WASM builds

### packages/jvm/groth16/groth16_jni
- Bump `pairing_ce` 0.18 → 0.28
- Align `ff_ce` (explicit dep) to 0.14 to avoid trait version mismatch

### packages/jvm/groth16/groth16_node/native
- Migrate from neon 0.3 → 1.1.1 API:
  - `register_module!` → `#[neon::main]`
  - Buffer borrows: `cx.borrow()` → `TypedArray::as_slice()` with block scopes
  - `cx.borrow_mut()` → `JsBuffer::from_slice()`
  - `downcast::<T>()` → `downcast::<T, _>(cx)`
  - `JsNumber::value()` → `value(&mut cx)`
  - `JsBoolean::new(&mut cx, b)` → `cx.boolean(b)`
  - `neon::result::Throw` literal → `cx.throw_error(...)` pattern
  - Remove `neon-build` build dependency; simplify `build.rs`

## Verified
- `cargo check -p groth16_jni` ✅
- `cargo build --target wasm32-unknown-unknown --release` (sdk/crypto) ✅
- Pre-commit typecheck: 37/37 tasks pass ✅

Closes #10
Closes #11
Closes #12