### PR TITLE
chore: trim minimumReleaseAgeExclude to only currently-needed entries

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,38 +64,10 @@ overrides:
 # This is intentional – the cycle is test-only and causes no runtime issues.
 ignoreWorkspaceCycles: true
 
+# pnpm supply-chain policy: packages published within ~1 day fail the
+# minimumReleaseAge lockfile check. List only entries that are genuinely
+# within the cutoff window; remove them once the package has aged past it.
 minimumReleaseAgeExclude:
-  - '@vitest/coverage-v8@4.1.8'
-  - '@vitest/expect@4.1.8'
-  - '@vitest/mocker@4.1.8'
-  - '@vitest/pretty-format@4.1.8'
-  - '@vitest/runner@4.1.8'
-  - '@vitest/snapshot@4.1.8'
-  - '@vitest/spy@4.1.8'
-  - '@vitest/utils@4.1.8'
-  - vitest@4.1.8
-  - vite@8.0.16
-  - knip@6.14.2
-  - hono@4.12.23
-  - nx@22.7.5
-  - '@nx/devkit@22.7.5'
-  - '@nx/vitest@22.7.5'
-  - '@hookform/resolvers@5.4.0'
-  - '@nx/nx-darwin-arm64@22.7.5'
-  - '@nx/nx-darwin-x64@22.7.5'
-  - '@nx/nx-freebsd-x64@22.7.5'
-  - '@nx/nx-linux-arm-gnueabihf@22.7.5'
-  - '@nx/nx-linux-arm64-gnu@22.7.5'
-  - '@nx/nx-linux-arm64-musl@22.7.5'
-  - '@nx/nx-linux-x64-gnu@22.7.5'
-  - '@nx/nx-linux-x64-musl@22.7.5'
-  - '@nx/nx-win32-arm64-msvc@22.7.5'
-  - '@nx/nx-win32-x64-msvc@22.7.5'
-  - '@nx/js@22.7.5'
-  - '@nx/workspace@22.7.5'
-  - tmp@0.2.6
-  - '@nx/eslint@22.7.5'
-  - '@nx/playwright@22.7.5'
   - '@sentry-internal/browser-utils@10.56.0'
   - '@sentry-internal/feedback@10.56.0'
   - '@sentry-internal/replay-canvas@10.56.0'


### PR DESCRIPTION
## Summary

Remove 31 stale version-pinned entries from `minimumReleaseAgeExclude` that have
long since aged past pnpm's 1-day supply-chain policy cutoff.

### What `minimumReleaseAgeExclude` is

pnpm v11 enforces a built-in supply-chain security policy: packages published
within ~1 day of `pnpm install` fail with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`.
The `minimumReleaseAgeExclude` list bypasses this check for specific entries so
that Dependabot bumps don't break the pre-commit lockfile validation hook.

### The antipattern fixed

Every Dependabot bump appended a new `package@version` entry but old ones were
never removed. The list had accumulated 31+ entries going back months — all stale,
none enforcing any actual policy benefit.

### New policy

**Keep only packages published within the ~1-day cutoff window.** Remove entries
once they age past it. The list is now 8 entries for packages published today
(`@sentry/* 10.56.0` and `cytoscape 3.34.0`); these will be removed on the
next cleanup pass once they've aged out.

A comment in `pnpm-workspace.yaml` documents this contract.