### PR TITLE
fix(ci): pin deploy-container.yml to infra@b3e42d4 (current main)

### DIFF
--- a/.github/workflows/deploy-bps.yml
+++ b/.github/workflows/deploy-bps.yml
@@ -140,7 +140,7 @@ jobs:
   call-deploy:
     name: Deploy (${{ needs.resolve.outputs.network }})
     needs: [resolve]
-    uses: Decentral-America/infra/.github/workflows/deploy-container.yml@0fc65e2ca5c82abcad32fcbe1125f1b59b40dfbf # main
+    uses: Decentral-America/infra/.github/workflows/deploy-container.yml@b3e42d4241174725be3678bed4360669ac2645c7 # main
     with:
       network: ${{ needs.resolve.outputs.network }}
       image:   ghcr.io/decentral-america/blockchain-postgres-sync:${{ github.sha }}

--- a/.github/workflows/deploy-data-service.yml
+++ b/.github/workflows/deploy-data-service.yml
@@ -147,7 +147,7 @@ jobs:
   call-deploy:
     name: Deploy (${{ needs.resolve.outputs.network }})
     needs: [resolve]
-    uses: Decentral-America/infra/.github/workflows/deploy-container.yml@0fc65e2ca5c82abcad32fcbe1125f1b59b40dfbf # main
+    uses: Decentral-America/infra/.github/workflows/deploy-container.yml@b3e42d4241174725be3678bed4360669ac2645c7 # main
     with:
       network: ${{ needs.resolve.outputs.network }}
       image:   ghcr.io/decentral-america/data-service:${{ github.sha }}

--- a/.github/workflows/deploy-scanner.yml
+++ b/.github/workflows/deploy-scanner.yml
@@ -168,7 +168,7 @@ jobs:
   call-deploy:
     name: Deploy (${{ needs.resolve.outputs.network }})
     needs: [resolve]
-    uses: Decentral-America/infra/.github/workflows/deploy-container.yml@0fc65e2ca5c82abcad32fcbe1125f1b59b40dfbf # main
+    uses: Decentral-America/infra/.github/workflows/deploy-container.yml@b3e42d4241174725be3678bed4360669ac2645c7 # main
     with:
       network: ${{ needs.resolve.outputs.network }}
       image:   ghcr.io/decentral-america/scanner:${{ github.sha }}


### PR DESCRIPTION
Previous SHA `0fc65e2` was stale and caused `startup_failure` when triggering the scanner deploy workflow. Updated all three deploy workflows to `b3e42d4` (current infra main, which includes the scanner `network_mode: host` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)