### PR TITLE
ci: consolidate Maven publish workflows into a reusable template

### DIFF
--- a/.github/workflows/_publish-maven.yml
+++ b/.github/workflows/_publish-maven.yml
@@ -1,0 +1,142 @@
+name: (reusable) Publish Maven package to Central Portal
+
+# Shared publish pipeline for single-module Maven/JVM packages in this monorepo.
+# Callers keep their own workflow_dispatch UI (package-specific version example/
+# default) and just forward inputs here via `uses:` + `with:`. Do not call this
+# directly — trigger the per-package publish-<name>.yml workflow instead.
+#
+# Packages with a fundamentally different shape stay out of this template:
+#   - groth16   → multi-platform Rust native-lib build matrix before publish
+#   - ride      → sbt (not Maven) + combined JVM/npm release
+
+on:
+  workflow_call:
+    inputs:
+      package-path:
+        description: 'Path to the Maven package (working-directory), e.g. packages/jvm/blst'
+        required: true
+        type: string
+      artifact-name:
+        description: 'Prefix for the uploaded staging artifact, e.g. blst'
+        required: true
+        type: string
+      version:
+        description: 'Release version to set via versions:set'
+        required: true
+        type: string
+      run-audit-profile:
+        description: 'Run the `-P audit` gate (OWASP dependency-check + SpotBugs + PMD) before deploy'
+        required: false
+        type: boolean
+        default: true
+      install-prereqs:
+        description: 'Newline-separated sibling package paths to `mvnw install` first (intra-monorepo deps not yet on Central)'
+        required: false
+        type: string
+        default: ''
+
+# Least-privilege token permissions (OWASP CI/CD A09), narrowed further at
+# job level for the two steps that need attestations/OIDC.
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Audit · Sign · Upload · Attest · Await approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write        # required for SLSA build provenance attestation
+      attestations: write    # required to publish the attestation to this repo
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.package-path }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25 (Temurin) + Maven Central credentials
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+
+      - name: Install prerequisite packages
+        if: ${{ inputs.install-prereqs != '' }}
+        env:
+          MVN_OPTS: --batch-mode --no-transfer-progress -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true
+          PREREQS: ${{ inputs.install-prereqs }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            (cd "$GITHUB_WORKSPACE/$path" && ./mvnw $MVN_OPTS install)
+          done <<< "$PREREQS"
+
+      - name: Set release version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          ./mvnw --batch-mode versions:set \
+            -DnewVersion="${RELEASE_VERSION}" \
+            -DgenerateBackupPoms=false
+
+      - name: Full audit gate before release
+        if: ${{ inputs.run-audit-profile }}
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "$NVD_API_KEY" ]; then
+            ./mvnw --batch-mode verify -P audit -DnvdApiKey="$NVD_API_KEY"
+          else
+            ./mvnw --batch-mode verify -P audit -Ddependency-check.skip=true
+          fi
+
+      - name: Build + verify
+        if: ${{ !inputs.run-audit-profile }}
+        run: ./mvnw --batch-mode --no-transfer-progress verify -Dgpg.skip=true
+
+      - name: GPG-sign and deploy to Central Portal
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
+        run: |
+          set -euo pipefail
+          ./mvnw --batch-mode deploy -P release -DskipTests \
+            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: ${{ inputs.package-path }}/target
+          format: spdx-json
+          artifact-name: ${{ inputs.artifact-name }}-${{ inputs.version }}.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
+      - name: Attest build provenance for published JARs
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ inputs.package-path }}/target/*.jar
+
+      - name: Upload staging artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}-${{ inputs.version }}
+          path: ${{ inputs.package-path }}/target/*.jar
+          retention-days: 30

--- a/.github/workflows/_publish-maven.yml
+++ b/.github/workflows/_publish-maven.yml
@@ -45,6 +45,7 @@ jobs:
     name: Audit · Sign · Upload · Attest · Await approval
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: maven-central-release
     permissions:
       contents: read
       id-token: write        # required for SLSA build provenance attestation

--- a/.github/workflows/publish-blst.yml
+++ b/.github/workflows/publish-blst.yml
@@ -15,68 +15,11 @@ concurrency:
   group: publish-blst
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: packages/jvm/blst
-
 jobs:
   publish:
-    name: Sign · Upload · Await approval
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 25 (Temurin) + Maven Central credentials
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '25'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-
-      - name: Set release version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode versions:set \
-            -DnewVersion="${RELEASE_VERSION}" \
-            -DgenerateBackupPoms=false
-
-      - name: Full audit gate before release
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -n "$NVD_API_KEY" ]; then
-            ./mvnw --batch-mode verify -P audit -DnvdApiKey="$NVD_API_KEY"
-          else
-            ./mvnw --batch-mode verify -P audit -Ddependency-check.skip=true
-          fi
-
-      - name: GPG-sign and deploy to Central Portal
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode deploy -P release -DskipTests \
-            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
-
-      - name: Upload staging artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: blst-${{ inputs.version }}
-          path: packages/jvm/blst/target/*.jar
-          retention-days: 30
+    uses: ./.github/workflows/_publish-maven.yml
+    secrets: inherit
+    with:
+      package-path: packages/jvm/blst
+      artifact-name: blst
+      version: ${{ inputs.version }}

--- a/.github/workflows/publish-crypto.yml
+++ b/.github/workflows/publish-crypto.yml
@@ -15,77 +15,15 @@ concurrency:
   group: publish-crypto
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: packages/jvm/crypto
-
 jobs:
   publish:
-    name: Sign · Upload · Await approval
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 25 (Temurin) + Maven Central credentials
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '25'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-
+    uses: ./.github/workflows/_publish-maven.yml
+    secrets: inherit
+    with:
+      package-path: packages/jvm/crypto
+      artifact-name: crypto
+      version: ${{ inputs.version }}
       # crypto depends on curve25519 + blst — install from source until they're on Central
-      - name: Install prerequisites (curve25519, blst)
-        env:
-          MVN_OPTS: --batch-mode --no-transfer-progress -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true
-        run: |
-          set -euo pipefail
-          (cd $GITHUB_WORKSPACE/packages/jvm/curve25519 && ./mvnw $MVN_OPTS install)
-          (cd $GITHUB_WORKSPACE/packages/jvm/blst        && ./mvnw $MVN_OPTS install)
-
-      - name: Set release version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode versions:set \
-            -DnewVersion="${RELEASE_VERSION}" \
-            -DgenerateBackupPoms=false
-
-      - name: Full audit gate before release
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -n "$NVD_API_KEY" ]; then
-            ./mvnw --batch-mode verify -P audit -DnvdApiKey="$NVD_API_KEY"
-          else
-            ./mvnw --batch-mode verify -P audit -Ddependency-check.skip=true
-          fi
-
-      - name: GPG-sign and deploy to Central Portal
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode deploy -P release -DskipTests \
-            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
-
-      - name: Upload staging artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: crypto-${{ inputs.version }}
-          path: packages/jvm/crypto/target/*.jar
-          retention-days: 30
+      install-prereqs: |
+        packages/jvm/curve25519
+        packages/jvm/blst

--- a/.github/workflows/publish-curve25519.yml
+++ b/.github/workflows/publish-curve25519.yml
@@ -15,68 +15,11 @@ concurrency:
   group: publish-curve25519
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: packages/jvm/curve25519
-
 jobs:
   publish:
-    name: Sign · Upload · Await approval
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 25 (Temurin) + Maven Central credentials
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '25'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-
-      - name: Set release version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode versions:set \
-            -DnewVersion="${RELEASE_VERSION}" \
-            -DgenerateBackupPoms=false
-
-      - name: Full audit gate before release
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -n "$NVD_API_KEY" ]; then
-            ./mvnw --batch-mode verify -P audit -DnvdApiKey="$NVD_API_KEY"
-          else
-            ./mvnw --batch-mode verify -P audit -Ddependency-check.skip=true
-          fi
-
-      - name: GPG-sign and deploy to Central Portal
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode deploy -P release -DskipTests \
-            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
-
-      - name: Upload staging artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: curve25519-${{ inputs.version }}
-          path: packages/jvm/curve25519/target/*.jar
-          retention-days: 30
+    uses: ./.github/workflows/_publish-maven.yml
+    secrets: inherit
+    with:
+      package-path: packages/jvm/curve25519
+      artifact-name: curve25519
+      version: ${{ inputs.version }}

--- a/.github/workflows/publish-groth16.yml
+++ b/.github/workflows/publish-groth16.yml
@@ -137,6 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build-native
+    environment: maven-central-release
     defaults:
       run:
         working-directory: packages/jvm/groth16

--- a/.github/workflows/publish-java-sdk.yml
+++ b/.github/workflows/publish-java-sdk.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. 1.6.5.0)'
+        description: 'Release version (e.g. 2.0.1)'
         required: true
         default: '2.0.1'
 
@@ -15,68 +15,11 @@ concurrency:
   group: publish-java-sdk
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: packages/jvm/java-sdk
-
 jobs:
   publish:
-    name: Sign · Upload · Await approval
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 25 (Temurin) + Maven Central credentials
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '25'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-
-      - name: Set release version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode versions:set \
-            -DnewVersion="${RELEASE_VERSION}" \
-            -DgenerateBackupPoms=false
-
-      - name: Full audit gate before release
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -n "$NVD_API_KEY" ]; then
-            ./mvnw --batch-mode verify -P audit -DnvdApiKey="$NVD_API_KEY"
-          else
-            ./mvnw --batch-mode verify -P audit -Ddependency-check.skip=true
-          fi
-
-      - name: GPG-sign and deploy to Central Portal
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode deploy -P release -DskipTests \
-            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
-
-      - name: Upload staging artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: java-sdk-${{ inputs.version }}
-          path: packages/jvm/java-sdk/target/*.jar
-          retention-days: 30
+    uses: ./.github/workflows/_publish-maven.yml
+    secrets: inherit
+    with:
+      package-path: packages/jvm/java-sdk
+      artifact-name: java-sdk
+      version: ${{ inputs.version }}

--- a/.github/workflows/publish-protobuf-schemas.yml
+++ b/.github/workflows/publish-protobuf-schemas.yml
@@ -15,60 +15,14 @@ concurrency:
   group: publish-protobuf-schemas
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: packages/sdk/protobuf-schemas
-
 jobs:
   publish:
-    name: Sign · Upload · Await approval
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 25 (Temurin) + Maven Central credentials
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '25'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-
-      - name: Set release version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode versions:set \
-            -DnewVersion="${RELEASE_VERSION}" \
-            -DgenerateBackupPoms=false
-
-      - name: Build + verify
-        run: ./mvnw --batch-mode --no-transfer-progress verify -Dgpg.skip=true
-
-      - name: GPG-sign and deploy to Central Portal
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode deploy -P release -DskipTests \
-            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
-
-      - name: Upload staging artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: protobuf-schemas-${{ inputs.version }}
-          path: packages/sdk/protobuf-schemas/target/*.jar
-          retention-days: 30
+    uses: ./.github/workflows/_publish-maven.yml
+    secrets: inherit
+    with:
+      package-path: packages/sdk/protobuf-schemas
+      artifact-name: protobuf-schemas
+      version: ${{ inputs.version }}
+      # protobuf-schemas' pom.xml has no `audit` Maven profile (unlike the other
+      # JVM packages) — skip until that gap is closed (see audit follow-up).
+      run-audit-profile: false

--- a/.github/workflows/publish-ride.yml
+++ b/.github/workflows/publish-ride.yml
@@ -36,6 +36,10 @@ jobs:
     name: Sign · Publish · Release (JVM + npm)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Gates the whole job (JVM + npm) behind a human approval. Maven Central
+    # side is additionally soft-gated by Central Portal's autoPublish:false;
+    # npm has no other gate, hence this environment.
+    environment: npm-release
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-transactions.yml
+++ b/.github/workflows/publish-transactions.yml
@@ -19,68 +19,11 @@ concurrency:
   group: publish-transactions
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: packages/jvm/transactions
-
 jobs:
   publish:
-    name: Sign · Upload · Await approval
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Java 25 (Temurin) + Maven Central credentials
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '25'
-          cache: maven
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-          server-id: central
-          server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_PASSWORD
-
-      - name: Set release version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode versions:set \
-            -DnewVersion="${RELEASE_VERSION}" \
-            -DgenerateBackupPoms=false
-
-      - name: Full audit gate before release
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -n "$NVD_API_KEY" ]; then
-            ./mvnw --batch-mode verify -P audit -DnvdApiKey="$NVD_API_KEY"
-          else
-            ./mvnw --batch-mode verify -P audit -Ddependency-check.skip=true
-          fi
-
-      - name: GPG-sign and deploy to Central Portal
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          MAVEN_GPG_KEY_ID: ${{ secrets.MAVEN_GPG_KEY_ID }}
-        run: |
-          set -euo pipefail
-          ./mvnw --batch-mode deploy -P release -DskipTests \
-            -Dgpg.keyname="${MAVEN_GPG_KEY_ID}"
-
-      - name: Upload staging artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: transactions-${{ inputs.version }}
-          path: packages/jvm/transactions/target/*.jar
-          retention-days: 30
+    uses: ./.github/workflows/_publish-maven.yml
+    secrets: inherit
+    with:
+      package-path: packages/jvm/transactions
+      artifact-name: transactions
+      version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: npm-release
     env:
       # Release workflow runs without NX Cloud access — disable cloud features
       # so nx tasks run locally instead of failing on unauthorized workspace.


### PR DESCRIPTION
## Summary
- Extracts the shared steps of publish-blst.yml, publish-crypto.yml, publish-curve25519.yml, publish-java-sdk.yml, publish-protobuf-schemas.yml, publish-transactions.yml into one workflow_call template (_publish-maven.yml), parameterized by package path / artifact name / audit-gate flag / prerequisite installs.
- Fixes publish-java-sdk.yml's version input description (said "e.g. 1.6.5.0", default was 2.0.1).
- Adds SBOM generation (anchore/sbom-action, same action already used by release.yml) and SLSA build provenance attestation (actions/attest-build-provenance, same action already used by deploy-bps.yml) to every Maven Central publish.
- groth16 (Rust native-lib build matrix) and ride (sbt + combined JVM/npm release) intentionally kept as their own workflows.

## Note for reviewer
protobuf-schemas' pom.xml has no `audit` Maven profile (unlike every other JVM package), so its caller passes run-audit-profile: false to preserve current behavior. Adding that profile is a separate follow-up.

## Test plan
- [x] ruby -ryaml parses all 7 changed/new files
- [x] actionlint across .github/workflows/ — no new errors beyond pre-existing style notes
- [ ] Dispatch one publish workflow on this branch before merging to confirm the reusable-workflow call resolves correctly