### PR TITLE
fix: production-readiness audit remediation (Rust, RIDE, frontend)

### DIFF
--- a/apps/admin-dashboard/biome.json
+++ b/apps/admin-dashboard/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/apps/admin-dashboard/src/entry.server.tsx
+++ b/apps/admin-dashboard/src/entry.server.tsx
@@ -11,6 +11,12 @@ import { logger } from '@/lib/logger';
 void migrateSchema();
 
 if (isUsingDefaultSecret()) {
+  if (process.env.NODE_ENV === 'production') {
+    logger.error(
+      'ADMIN_DASHBOARD_JWT_SECRET is not set or uses the default dev value — refusing to start in production. Set a strong random secret via the ADMIN_DASHBOARD_JWT_SECRET environment variable.',
+    );
+    process.exit(1);
+  }
   logger.warn(
     'ADMIN_DASHBOARD_JWT_SECRET is not set or uses the default — set a strong random secret before deploying',
   );

--- a/apps/admin-dashboard/src/lib/target-nodes.ts
+++ b/apps/admin-dashboard/src/lib/target-nodes.ts
@@ -1,0 +1,25 @@
+// Allowlist of nodes the Load Test / Treasury tooling is permitted to target.
+// Kept as a fixed list (not free text) so operators can't accidentally — or
+// deliberately — point traffic-generating tools at an arbitrary host.
+//
+// gen-0/gen-1/val-0 aren't listed: they run inside the LKE cluster and are
+// only reachable via `kubectl port-forward`, not from wherever this dashboard
+// is deployed (see infra/clusters/testnet/apps/nodes.yaml). Add them here once
+// there's a network path the dashboard can actually reach them over.
+export interface TargetNode {
+  label: string;
+  url: string;
+}
+
+const MAIN_NODE: TargetNode = {
+  label: 'Main Node (testnet)',
+  url: 'https://testnet-node.decentralchain.io',
+};
+
+export const TARGET_NODES: readonly TargetNode[] = [MAIN_NODE] as const;
+
+export const DEFAULT_TARGET_NODE = MAIN_NODE.url;
+
+export function isAllowedTargetNode(url: string): boolean {
+  return TARGET_NODES.some((n) => n.url === url);
+}

--- a/apps/admin-dashboard/src/pages/LoadTest.tsx
+++ b/apps/admin-dashboard/src/pages/LoadTest.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { DEFAULT_TARGET_NODE, TARGET_NODES } from '@/lib/target-nodes';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -34,7 +36,7 @@ interface FinalSummary {
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function LoadTest() {
-  const [targetNode, setTargetNode] = useState('');
+  const [targetNode, setTargetNode] = useState(DEFAULT_TARGET_NODE);
   const [workers, setWorkers] = useState('200');
   const [targetTps, setTargetTps] = useState('500');
   const [duration, setDuration] = useState('300');
@@ -208,13 +210,18 @@ export default function LoadTest() {
             <label htmlFor="lt-node" className="text-sm font-medium">
               Target Node URL
             </label>
-            <Input
+            <Select
               id="lt-node"
               value={targetNode}
               onChange={(e) => setTargetNode(e.target.value)}
-              placeholder="https://testnet-node.decentralchain.io"
               disabled={running}
-            />
+            >
+              {TARGET_NODES.map((n) => (
+                <option key={n.url} value={n.url}>
+                  {n.label}
+                </option>
+              ))}
+            </Select>
           </div>
           <div className="flex flex-col gap-1.5">
             <label htmlFor="lt-workers" className="text-sm font-medium">

--- a/apps/admin-dashboard/src/routes/api.e2e.stream.ts
+++ b/apps/admin-dashboard/src/routes/api.e2e.stream.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from 'react-router';
 import { getTokenFromRequest, verifyToken } from '@/lib/auth';
 import { logger } from '@/lib/logger';
@@ -149,6 +150,18 @@ export async function action({ request }: ActionFunctionArgs) {
     const runId = crypto.randomUUID();
     const suitePath = process.env.E2E_SUITE_PATH ?? '/opt/dcc/DecentralChain';
 
+    if (!existsSync(suitePath)) {
+      // Deliberately unset in production (compose/admin-dashboard.yml sets
+      // E2E_SUITE_PATH=/dev/null/disabled — the image ships only itself, not
+      // the full monorepo). Any other missing path is a real misconfiguration.
+      const message =
+        suitePath === '/dev/null/disabled'
+          ? 'E2E test suite is disabled in this environment.'
+          : `E2E suite not found at "${suitePath}". Mount the DecentralChain checkout at that path, or set E2E_SUITE_PATH to its location.`;
+      logger.error({ suitePath, user }, 'E2E run: suite path missing');
+      return new Response(message, { status: 503 });
+    }
+
     // Accept explicit spec list or fall back to suite presets
     const customSpecs = Array.isArray(body.specs) ? (body.specs as string[]) : null;
     const suite: E2ESuite =
@@ -169,6 +182,16 @@ export async function action({ request }: ActionFunctionArgs) {
       cwd: suitePath,
       env: { ...process.env },
       stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    // Without this, a spawn-time failure (bad cwd, command not found) emits an
+    // 'error' event with no listener attached yet — Node treats that as an
+    // unhandled exception and crashes the process. The loader() SSE stream
+    // attaches its own listener once the client connects, but that can be
+    // seconds after spawn(); this one exists purely to survive the gap.
+    child.once('error', (err) => {
+      logger.error({ err, runId, suitePath }, 'E2E process failed to start');
+      runs.delete(runId);
     });
 
     runs.set(runId, child);

--- a/apps/admin-dashboard/src/routes/api.load-test.stream.ts
+++ b/apps/admin-dashboard/src/routes/api.load-test.stream.ts
@@ -3,6 +3,7 @@ import { type ActionFunctionArgs, type LoaderFunctionArgs } from 'react-router';
 import { getTokenFromRequest, verifyToken } from '@/lib/auth';
 import { getSql } from '@/lib/db';
 import { logger } from '@/lib/logger';
+import { isAllowedTargetNode } from '@/lib/target-nodes';
 
 async function getUser(request: Request): Promise<string | null> {
   const token = getTokenFromRequest(request);
@@ -37,8 +38,8 @@ function validateStartParams(
 ): { ok: true; params: StartParams } | { ok: false; error: string } {
   const { targetNode, workers, targetTps, duration, seedPhrase, chainId, senderCount } = body;
 
-  if (typeof targetNode !== 'string' || !/^https?:\/\/.+/.test(targetNode)) {
-    return { error: 'targetNode must be a valid HTTP(S) URL', ok: false };
+  if (typeof targetNode !== 'string' || !isAllowedTargetNode(targetNode)) {
+    return { error: 'targetNode must be one of the allowlisted testnet nodes', ok: false };
   }
   const workersNum = Number(workers);
   if (!Number.isInteger(workersNum) || workersNum < 1 || workersNum > 2000) {

--- a/apps/blockchain-postgres-sync/Cargo.lock
+++ b/apps/blockchain-postgres-sync/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
  "envy",
  "fred",
  "hex",
- "itertools",
+ "itertools 0.15.0",
  "proptest",
  "prost",
  "r2d2",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1375,6 +1375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1837,7 +1846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1853,12 +1862,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2559,7 +2568,7 @@ dependencies = [
  "ferroid",
  "futures",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",

--- a/apps/blockchain-postgres-sync/Cargo.toml
+++ b/apps/blockchain-postgres-sync/Cargo.toml
@@ -63,7 +63,7 @@ regex = "1"
 
 # Utilities
 chrono = { version = "0.4", features = ["serde"] }
-itertools = "0.14.0"
+itertools = "0.15.0"
 
 # HTTP server (health / readiness endpoint)
 axum = { version = "0.8.9", features = ["tokio"] }

--- a/apps/blockchain-postgres-sync/src/bin/consumer.rs
+++ b/apps/blockchain-postgres-sync/src/bin/consumer.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use app_lib::{config, consumer, db, publisher};
-use axum::{Router, routing::get};
+use axum::{Router, extract::State, routing::get};
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::select;
 use tracing::{error, info};
 use tracing_subscriber::{EnvFilter, fmt};
@@ -46,11 +48,14 @@ async fn main() -> Result<()> {
         }
     };
 
-    // Health / readiness HTTP server
+    // Health / readiness / metrics HTTP server
     let metrics_port = config.consumer.metrics_port;
     let health_conn = conn.clone();
-    let health_server = tokio::spawn(async move {
-        let app = Router::new()
+    let last_synced_height = Arc::new(AtomicU32::new(0));
+    let health_server = tokio::spawn({
+        let last_synced_height = last_synced_height.clone();
+        async move {
+            let app = Router::new()
             .route("/health", get(|| async { "OK" }))
             .route(
                 "/readiness",
@@ -64,19 +69,44 @@ async fn main() -> Result<()> {
                         )
                     }
                 }),
-            );
+            )
+            .route(
+                "/metrics",
+                get(|State(height): State<Arc<AtomicU32>>| async move {
+                    let height = height.load(Ordering::Relaxed);
+                    (
+                        [("content-type", "text/plain; version=0.0.4")],
+                        format!(
+                            "# HELP bps_up Whether the BPS consumer process is running.\n\
+                             # TYPE bps_up gauge\n\
+                             bps_up 1\n\
+                             # HELP bps_last_synced_height Last blockchain height committed to Postgres.\n\
+                             # TYPE bps_last_synced_height gauge\n\
+                             bps_last_synced_height {height}\n"
+                        ),
+                    )
+                }),
+            )
+            .with_state(last_synced_height);
 
-        let addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
-        let listener = tokio::net::TcpListener::bind(addr)
-            .await
-            .context("health listener bind failed")?;
-        info!(%addr, "health server listening");
-        axum::serve(listener, app)
-            .await
-            .context("health server failed")
+            let addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
+            let listener = tokio::net::TcpListener::bind(addr)
+                .await
+                .context("health listener bind failed")?;
+            info!(%addr, "health server listening");
+            axum::serve(listener, app)
+                .await
+                .context("health server failed")
+        }
     });
 
-    let consumer = consumer::start(updates_src, pg_repo, config.consumer, redis_publisher);
+    let consumer = consumer::start(
+        updates_src,
+        pg_repo,
+        config.consumer,
+        redis_publisher,
+        last_synced_height,
+    );
 
     select! {
         result = consumer => {

--- a/apps/blockchain-postgres-sync/src/lib/consumer/mod.rs
+++ b/apps/blockchain-postgres-sync/src/lib/consumer/mod.rs
@@ -15,7 +15,8 @@ use bigdecimal::BigDecimal;
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use itertools::Itertools;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::mpsc::Receiver;
 use tracing::{debug, info, warn};
@@ -115,6 +116,7 @@ pub async fn start<T, R>(
     repo: R,
     config: Config,
     publisher: Option<crate::publisher::Publisher>,
+    last_synced_height: Arc<AtomicU32>,
 ) -> Result<()>
 where
     T: UpdatesSource + Send + 'static,
@@ -218,6 +220,10 @@ where
                 Ok(result)
             })
             .await?;
+
+        // Only advances after the transaction above commits, so the metric never
+        // reports a height whose data isn't actually queryable yet.
+        last_synced_height.store(last_height, Ordering::Relaxed);
 
         // Publish after the transaction commits — Redis failures are fire-and-forget.
         if let Some(ref pub_) = publisher {

--- a/apps/blockchain-postgres-sync/src/lib/consumer/updates.rs
+++ b/apps/blockchain-postgres-sync/src/lib/consumer/updates.rs
@@ -153,8 +153,13 @@ impl UpdatesSourceImpl {
                 ));
             };
 
-            last_height =
-                u32::try_from(update.height).expect("blockchain height is always non-negative");
+            last_height = u32::try_from(update.height).map_err(|e| {
+                error!(
+                    "received invalid (negative) block height {}: {}",
+                    update.height, e
+                );
+                AppError::StreamError(format!("invalid block height {}: {e}", update.height))
+            })?;
             match BlockchainUpdate::try_from(update) {
                 Ok(upd) => {
                     let current_batch_size = result.len() + 1;

--- a/apps/blockchain-postgres-sync/tests/consumer_repo.rs
+++ b/apps/blockchain-postgres-sync/tests/consumer_repo.rs
@@ -10,7 +10,12 @@
 
 #![allow(clippy::unwrap_used)]
 
-use diesel::{Connection, RunQueryDsl, pg::PgConnection, sql_query};
+use diesel::{
+    Connection, RunQueryDsl,
+    pg::PgConnection,
+    sql_query,
+    sql_types::{Integer, Nullable, VarChar},
+};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
 use testcontainers_modules::postgres::Postgres;
@@ -55,16 +60,14 @@ fn insert_block(conn: &mut PgConnection, id: &str, height: i32, time_stamp: Opti
         uid: i64,
     }
 
-    let ts_expr = match time_stamp {
-        Some(ts) => format!("'{ts}'::timestamptz"),
-        None => "NULL".to_string(),
-    };
-
-    let rows: Vec<Uid> = sql_query(format!(
+    let rows: Vec<Uid> = sql_query(
         "INSERT INTO blocks_microblocks (id, height, time_stamp) \
-         VALUES ('{id}', {height}, {ts_expr}) \
-         RETURNING uid"
-    ))
+         VALUES ($1, $2, $3::timestamptz) \
+         RETURNING uid",
+    )
+    .bind::<VarChar, _>(id)
+    .bind::<Integer, _>(height)
+    .bind::<Nullable<VarChar>, _>(time_stamp)
     .load(conn)
     .unwrap();
 

--- a/apps/scanner/src/root.tsx
+++ b/apps/scanner/src/root.tsx
@@ -81,7 +81,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <script
             // biome-ignore lint/security/noDangerouslySetInnerHtml: controlled server data, not user input
             dangerouslySetInnerHTML={{
-              __html: `window.__DCC_CONFIG__=${JSON.stringify(config)};`,
+              // Escape "<" so a future value containing "</script>" can't break out of this
+              // script tag context (e.g. via "</script><script>...").
+              __html: `window.__DCC_CONFIG__=${JSON.stringify(config).replace(/</g, '\\u003c')};`,
             }}
           />
         )}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -76,7 +76,7 @@ services:
 
   # ── Blockchain Postgres Sync (BPS) ──────────────────────────────────────────
   dcc-bps:
-    image: ghcr.io/decentral-america/blockchain-postgres-sync:latest
+    image: ghcr.io/decentral-america/blockchain-postgres-sync:latest@sha256:78e1f1920bcf007cab5c80a7b46913de61bfb11e84f414c1b67f87c559c9db71
     container_name: dcc-test-bps
     depends_on:
       dcc-node:

--- a/packages/ride/KNOWN_ISSUES.md
+++ b/packages/ride/KNOWN_ISSUES.md
@@ -63,6 +63,60 @@ parser, compiler, estimator, and repl logic only.
 **Tracking**: sbt-scoverage issue tracker — upgrade to a future version of
 sbt-scoverage that fixes Scala 3 closure instrumentation.
 
+### 3a. Re-investigated 2026-07-05 — no scoverage upgrade available; JaCoCo spiked and rejected
+
+**sbt-scoverage upgrade path: not available.** `2.4.4` is the *latest* published
+release of `sbt-scoverage` as of this investigation (confirmed against both the
+GitHub releases API and the Maven Central artifact listing for
+`org.scoverage:sbt-scoverage_2.12_1.0` — `2.4.4` is the newest version on both).
+The underlying `scalac-scoverage-plugin` has since published `2.5.0`–`2.5.2`, but
+their changelogs contain no mention of a Scala 3 closure/boxing fix (bumped
+scala-xml, added Scala 2.12.21 support, added "incremental coverage support" —
+nothing related to KNOWN-3), and `sbt-scoverage` itself has not picked up a build
+against them. There is currently nothing newer to bump to. Re-check this
+periodically by re-running the Maven Central listing check below; do not assume
+this is permanent.
+
+```
+curl -s https://repo1.maven.org/maven2/org/scoverage/sbt-scoverage_2.12_1.0/ \
+  | grep -oE 'href="[0-9][^"]*/"' | sed 's/href="//;s/\/"//' | sort -V | tail -5
+```
+
+**JaCoCo spike: attempted, reverted.** `sbt-jacoco` (`com.github.sbt % sbt-jacoco`,
+latest `3.6.0`) is actively maintained (releases as recently as this month) and,
+because it instruments compiled `.class` bytecode rather than doing AST/compiler-
+plugin instrumentation, it does not go anywhere near the Scala-3-compiler-integrated
+instrumentation path that causes KNOWN-3. A spike was run: added the plugin,
+enabled `JacocoItPlugin` on `lang-jvm`, scoped it to the evaluator package via
+`jacocoIncludes := Seq("com.decentralchain.lang.v1.evaluator.*")`, and ran
+`sbt lang/jacoco`. It instrumented successfully (911 classes, no BoxedUnit/
+ClassCastException), but reported **0 % coverage across the board**. Root cause:
+`sbt-jacoco`'s `jacoco` task instruments and runs `Test/test` *within the project
+it's scoped to*. The evaluator's actual exercising tests live in `lang-tests`
+(depending on `lang-testkit` → `lang-jvm`), not in `lang-jvm` itself — `lang-jvm`
+has no evaluator-exercising tests of its own, so nothing meaningful ran against the
+instrumented classes. Getting a real number out of JaCoCo here would require either:
+- pointing `lang-tests`'s test JVM at a JaCoCo javaagent targeting `lang-jvm`'s
+  instrumented classes and merging/reporting cross-project (undocumented for this
+  plugin, would need custom wiring), or
+- moving/duplicating the relevant evaluator tests into `lang-jvm` itself (would
+  fragment the existing `lang-tests` test organization for no other benefit).
+
+Both are a materially larger lift than "add a plugin and flip a setting," and
+their risk (fragile cross-project javaagent wiring, or restructuring test layout)
+is disproportionate to the payoff (a coverage *percentage*, when evaluator
+*correctness* is already fully covered by the un-instrumented `sbt test` run).
+The spike was fully reverted (`git diff` against `project/plugins.sbt` and
+`build.sbt` is clean) — no plugin bump or setting change was kept.
+
+**Recommendation**: leave KNOWN-3 open as-is (evaluator excluded from scoverage
+instrumentation, correctness verified by uninstrumented `sbt test`). If a team
+member wants to pursue JaCoCo further, the actual remaining work is the
+cross-project instrumentation wiring described above — budget roughly half a day
+for a spike of that specific mechanism (javaagent + report merge) before deciding
+whether it's worth adopting permanently, since it's unproven and undocumented for
+this multi-project-with-shared-test-project shape.
+
 ## 4. `com.wavesplatform.*` imports — RESOLVED (2026-05-19)
 
 The DCC-252 AC "zero `com.wavesplatform.lang` in .scala files" is satisfied:

--- a/packages/ride/build.sbt
+++ b/packages/ride/build.sbt
@@ -57,7 +57,7 @@ ThisBuild / pgpPassphrase          := sys.env.get("MAVEN_GPG_PASSPHRASE").map(_.
 
 inScope(Global)(
   Seq(
-    scalaVersion         := "3.8.3",
+    scalaVersion         := "3.8.4",
     organization         := "io.decentralchain",
     organizationName     := "DecentralChain",
     organizationHomepage := Some(url("https://decentralchain.io")),

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/utils/package.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/utils/package.scala
@@ -29,29 +29,51 @@ package object utils {
 
   val environment: Environment[Id] = buildEnvironment(ByteStr.empty)
 
+  // This is a dummy/placeholder Environment used only by InvariableContext to evaluate
+  // vals that are statically known to be "pure" (i.e. environment-independent, see
+  // v1.evaluator.ctx.InvariableContext). None of the methods below should ever be invoked in
+  // normal operation: if one is, it means a value marked `isPure` actually reads from the
+  // environment, which is an invariant violation elsewhere in the context-building logic.
+  private def unreachableEnvironmentCall(methodName: String): Nothing =
+    throw new IllegalStateException(
+      s"Unreachable: Environment.$methodName invoked on the dummy/pure-only environment " +
+        s"(com.decentralchain.lang.utils.environment). This placeholder is only supposed to be used " +
+        s"to evaluate vals marked as environment-independent ('isPure') in InvariableContext; " +
+        s"reaching this means a value was incorrectly marked pure while actually depending on the environment."
+    )
+
   def buildEnvironment(txIdParam: ByteStr): Environment[Id] = new Environment[Id] {
-    override def height: Long                                                                  = 0
-    override def chainId: Byte                                                                 = 1: Byte
-    override def inputEntity: Environment.InputEntity                                          = null
-    override val txId: ByteStr                                                                 = txIdParam
-    override def transactionById(id: Array[Byte]): Option[Tx]                                  = ???
-    override def transferTransactionById(id: Array[Byte]): Option[Tx.Transfer]                 = ???
-    override def transactionHeightById(id: Array[Byte]): Option[Long]                          = ???
-    override def assetInfoById(id: Array[Byte]): Option[ScriptAssetInfo]                       = ???
-    override def lastBlockOpt(): Option[BlockInfo]                                             = ???
-    override def blockInfoByHeight(height: Int): Option[BlockInfo]                             = ???
+    override def height: Long                                 = 0
+    override def chainId: Byte                                = 1: Byte
+    override def inputEntity: Environment.InputEntity         = null
+    override val txId: ByteStr                                = txIdParam
+    override def transactionById(id: Array[Byte]): Option[Tx] = unreachableEnvironmentCall("transactionById")
+    override def transferTransactionById(id: Array[Byte]): Option[Tx.Transfer] =
+      unreachableEnvironmentCall("transferTransactionById")
+    override def transactionHeightById(id: Array[Byte]): Option[Long] =
+      unreachableEnvironmentCall("transactionHeightById")
+    override def assetInfoById(id: Array[Byte]): Option[ScriptAssetInfo] = unreachableEnvironmentCall("assetInfoById")
+    override def lastBlockOpt(): Option[BlockInfo]                       = unreachableEnvironmentCall("lastBlockOpt")
+    override def blockInfoByHeight(height: Int): Option[BlockInfo] = unreachableEnvironmentCall("blockInfoByHeight")
     override def data(addressOrAlias: Recipient, key: String, dataType: DataType): Option[Any] = None
-    override def hasData(addressOrAlias: Recipient): Boolean                                   = ???
-    override def accountBalanceOf(addressOrAlias: Recipient, assetId: Option[Array[Byte]]): Either[String, Long] = ???
-    override def accountDccBalanceOf(addressOrAlias: Recipient): Either[String, Environment.BalanceDetails]      = ???
-    override def resolveAlias(name: String): Either[String, Recipient.Address]                                   = ???
+    override def hasData(addressOrAlias: Recipient): Boolean = unreachableEnvironmentCall("hasData")
+    override def accountBalanceOf(addressOrAlias: Recipient, assetId: Option[Array[Byte]]): Either[String, Long] =
+      unreachableEnvironmentCall("accountBalanceOf")
+    override def accountDccBalanceOf(addressOrAlias: Recipient): Either[String, Environment.BalanceDetails] =
+      unreachableEnvironmentCall("accountDccBalanceOf")
+    override def resolveAlias(name: String): Either[String, Recipient.Address] = unreachableEnvironmentCall(
+      "resolveAlias"
+    )
     override def tthis: Environment.Tthis                                          = Recipient.Address(ByteStr.empty)
     override def multiPaymentAllowed: Boolean                                      = true
-    override def transferTransactionFromProto(b: Array[Byte]): Option[Tx.Transfer] = ???
-    override def addressFromString(address: String): Either[String, Recipient.Address] = ???
-    override def addressFromPublicKey(publicKey: ByteStr): Either[String, Address]     = ???
-    override def accountScript(addressOrAlias: Recipient): Option[Script]              = ???
-    override def calculateDelay(gt: ByteStr, b: Long): Long                            = ???
+    override def transferTransactionFromProto(b: Array[Byte]): Option[Tx.Transfer] =
+      unreachableEnvironmentCall("transferTransactionFromProto")
+    override def addressFromString(address: String): Either[String, Recipient.Address] =
+      unreachableEnvironmentCall("addressFromString")
+    override def addressFromPublicKey(publicKey: ByteStr): Either[String, Address] =
+      unreachableEnvironmentCall("addressFromPublicKey")
+    override def accountScript(addressOrAlias: Recipient): Option[Script] = unreachableEnvironmentCall("accountScript")
+    override def calculateDelay(gt: ByteStr, b: Long): Long               = unreachableEnvironmentCall("calculateDelay")
     override def callScript(
         dApp: Address,
         func: String,
@@ -59,7 +81,7 @@ package object utils {
         payments: Seq[(Option[Array[Byte]], Long)],
         availableComplexity: Int,
         reentrant: Boolean
-    ): Coeval[(Either[ValidationError, (EVALUATED, Log[Id])], Int)] = ???
+    ): Coeval[(Either[ValidationError, (EVALUATED, Log[Id])], Int)] = unreachableEnvironmentCall("callScript")
   }
 
   val lazyContexts: Map[(DirectiveSet, Boolean, Boolean, Boolean), Coeval[CTX[Environment]]] =

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/ContractCompiler.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/ContractCompiler.scala
@@ -19,6 +19,7 @@ import com.decentralchain.lang.v1.compiler.CompilationError.{
 }
 import com.decentralchain.lang.v1.compiler.CompilerContext.VariableInfo
 import com.decentralchain.lang.v1.compiler.ContractCompiler.*
+import com.decentralchain.lang.v1.compiler.ExpressionCompiler.getValidated
 import com.decentralchain.lang.v1.compiler.ScriptResultSource.FreeCall
 import com.decentralchain.lang.v1.compiler.Terms.EXPR
 import com.decentralchain.lang.v1.compiler.Types.{BOOLEAN, BYTESTR, LONG, STRING}
@@ -106,7 +107,13 @@ class ContractCompiler(version: StdLibVersion) extends ExpressionCompiler(versio
       parseNodeExpr = af.copy(f = compiledBody._1.parseNodeExpr.asInstanceOf[Expressions.FUNC])
       resultAnnFunc =
         if (annotatedFuncWithErr._2.isEmpty && !compiledBody._1.dec.isItFailed) {
-          Some(annotatedFuncWithErr._1.get)
+          Some(
+            getValidated(
+              annotatedFuncWithErr._1,
+              annotatedFuncWithErr._2,
+              "compileAnnotatedFunc: annotated function result"
+            )
+          )
         } else {
           None
         }
@@ -160,7 +167,7 @@ class ContractCompiler(version: StdLibVersion) extends ExpressionCompiler(versio
               Iterable[CompilationError]
           )
         ](af => local(compileAnnotatedFunc(af, saveExprContext, allowIllFormedStrings, source)))
-      annotatedFuncs   = compiledAnnFuncsWithErr.filter(_._1.nonEmpty).map(_._1.get)
+      annotatedFuncs   = compiledAnnFuncsWithErr.flatMap(_._1)
       parsedNodeAFuncs = compiledAnnFuncsWithErr.map(_._3)
 
       duplicatedFuncNames = annotatedFuncs
@@ -196,8 +203,10 @@ class ContractCompiler(version: StdLibVersion) extends ExpressionCompiler(versio
         .handleError()
 
       callableFuncsWithParams = compiledAnnFuncsWithErr.filter(_._1.exists(_.isInstanceOf[CallableFunction]))
-      callableFuncs           = callableFuncsWithParams.map(_._1.get.asInstanceOf[CallableFunction])
-      callableFuncsTypeInfo   = callableFuncsWithParams.map { case (_, typedParams, _, _) =>
+      callableFuncs           = callableFuncsWithParams.map(t =>
+        getValidated(t._1, "compileContract: callable function narrowing").asInstanceOf[CallableFunction]
+      )
+      callableFuncsTypeInfo = callableFuncsWithParams.map { case (_, typedParams, _, _) =>
         typedParams.map(_._2)
       }
 
@@ -244,7 +253,12 @@ class ContractCompiler(version: StdLibVersion) extends ExpressionCompiler(versio
       result =
         if (errorList.isEmpty && !compiledAnnFuncsWithErr.exists(_._1.isEmpty)) {
 
-          var resultDApp = DApp(metaWithErr._1.get, decs, callableFuncs, verifierFuncOptWithErr._1.get)
+          var resultDApp = DApp(
+            getValidated(metaWithErr._1, errorList, "compileContract: DApp meta"),
+            decs,
+            callableFuncs,
+            getValidated(verifierFuncOptWithErr._1, errorList, "compileContract: verifier function")
+          )
 
           if (removeUnusedCode) resultDApp = ContractScriptCompactor.removeUnusedCode(resultDApp)
           if (needCompaction) {
@@ -430,7 +444,7 @@ object ContractCompiler {
           .flatMap(res =>
             Either.cond(
               res._3.isEmpty,
-              res._1.get,
+              getValidated(res._1, res._3, "ContractCompiler.apply: successful compilation result"),
               s"Compilation failed: [${res._3.map(e => Show[CompilationError].show(e)).mkString("; ")}]"
             )
           )
@@ -489,8 +503,14 @@ object ContractCompiler {
                      else
                        List(
                          Generic(
-                           removedCharPosOpt.get.start,
-                           removedCharPosOpt.get.end,
+                           getValidated(
+                             removedCharPosOpt,
+                             "compileWithParseResult: removed-char recovery position"
+                           ).start,
+                           getValidated(
+                             removedCharPosOpt,
+                             "compileWithParseResult: removed-char recovery position"
+                           ).end,
                            "Parsing failed. Some chars was removed as result of recovery process."
                          )
                        ))

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/ExpressionCompiler.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/ExpressionCompiler.scala
@@ -353,7 +353,7 @@ class ExpressionCompiler(val version: StdLibVersion) {
         if (errorList.isEmpty) {
           CompilationStepResultDec(
             ctx,
-            LET(letNameWithErr._1.get, compiledLet.expr),
+            LET(getValidated(letNameWithErr._1, errorList, "compileLet: LET name"), compiledLet.expr),
             letType,
             parseNodeDecl,
             compiledLet.errors
@@ -402,7 +402,11 @@ class ExpressionCompiler(val version: StdLibVersion) {
         if (errorList.isEmpty) {
           CompilationStepResultDec(
             ctx,
-            FUNC(funcNameWithErr._1.get, argTypesWithErr._1.get.map(_._1), compiledFuncBody.expr),
+            FUNC(
+              getValidated(funcNameWithErr._1, errorList, "compileFunc: FUNC name"),
+              getValidated(argTypesWithErr._1, errorList, "compileFunc: FUNC arg types").map(_._1),
+              compiledFuncBody.expr
+            ),
             compiledFuncBody.t,
             parseNodeDecl,
             compiledFuncBody.errors
@@ -532,7 +536,7 @@ class ExpressionCompiler(val version: StdLibVersion) {
 
       result =
         if (errorList.isEmpty) {
-          val (ctx, expr, t) = getterWithErr._1.get
+          val (ctx, expr, t) = getValidated(getterWithErr._1, errorList, "compileGetter: getter result")
           CompilationStepResultExpr(ctx, expr, t, parseNodeExpr.copy(resultType = Some(t)), compiledRef.errors)
         } else {
           CompilationStepResultExpr(ctx, FAILED_EXPR(), NOTHING, parseNodeExpr, errorList ++ compiledRef.errors)
@@ -579,7 +583,7 @@ class ExpressionCompiler(val version: StdLibVersion) {
 
       result =
         if (errorList.isEmpty) {
-          val (expr, t) = funcCallWithErr._1.get
+          val (expr, t) = getValidated(funcCallWithErr._1, errorList, "compileFunctionCall: resolved call")
           CompilationStepResultExpr(ctx, expr, t, parseNodeExpr, argErrorList)
         } else {
           CompilationStepResultExpr(ctx, FAILED_EXPR(), NOTHING, parseNodeExpr, errorList ++ argErrorList)
@@ -617,8 +621,8 @@ class ExpressionCompiler(val version: StdLibVersion) {
         if (errorList.isEmpty) {
           CompilationStepResultExpr(
             ctx,
-            REF(keyWithErr._1.get),
-            typeWithErr._1.get,
+            REF(getValidated(keyWithErr._1, errorList, "compileRef: resolved key")),
+            getValidated(typeWithErr._1, errorList, "compileRef: resolved type"),
             Expressions.REF(p, keyPart, typeWithErr._1, saveExprContext.toOption(ctx))
           )
         } else {
@@ -800,7 +804,10 @@ class ExpressionCompiler(val version: StdLibVersion) {
                     )
                   Right(makeIfCase(typeIf, blockWithNewVar, further))
                 case Nil =>
-                  ???
+                  throw new IllegalStateException(
+                    "Unreachable: matched TypedVar against UNION(types, _) with an empty type name list. " +
+                      "UNION(Nil, _) is matched by a preceding case, so 'types' here is guaranteed non-empty."
+                  )
               }
             } yield cases
           case (_: TypedVar, t) =>
@@ -971,7 +978,12 @@ class ExpressionCompiler(val version: StdLibVersion) {
             case Expressions.Single(PART.VALID(pos, Type.ListTypeName), Some(PART.VALID(_, Expressions.AnyType(_)))) =>
               val t = PART.VALID(pos, "List[Any]")
               List(t)
-            case _ => ???
+            case other =>
+              throw new IllegalStateException(
+                s"Unreachable: resolveTypesFromCompositePattern encountered union member $other. " +
+                  s"Only plain named types (Single(_, None)) and 'List[Any]' (Single(ListTypeName, Some(AnyType))) " +
+                  s"are permitted as union pattern members by the parser/prior validation."
+              )
           }
           .reduceRight[Seq[PART[String]]] { (ct, rt) =>
             rt ++ ct
@@ -988,8 +1000,13 @@ class ExpressionCompiler(val version: StdLibVersion) {
         List(t)
       case (_, TypedVar(_, Expressions.Single(t, None))) =>
         List(t)
-      case (_, TypedVar(_, Expressions.Single(_, _))) => ???
-      case (_, pat @ ConstsPat(consts, _))            =>
+      case (_, TypedVar(_, Expressions.Single(t, typeArg))) =>
+        throw new IllegalStateException(
+          s"Unreachable: resolveTypesFromCompositePattern encountered TypedVar with a parameterized Single " +
+            s"type ($t, $typeArg) that isn't the 'List[Any]' case handled above. Type parameters are only " +
+            s"permitted on List types by the parser/prior validation."
+        )
+      case (_, pat @ ConstsPat(consts, _)) =>
         val pos = pat.position
         consts
           .map { c =>
@@ -1093,6 +1110,44 @@ object ExpressionCompiler {
     final def toOption[A](a: => A): Option[A] = if (b) Some(a) else None
   }
 
+  /** Unwraps an `Option` that is expected to be `Some` whenever a paired list of compilation errors is empty — the
+    * idiom used throughout the compiler where a value and its potential errors are threaded together and the value is
+    * only consumed once the caller has confirmed there were no errors.
+    *
+    * This is not a behavior change from a raw `.get`: today's call sites already guarantee the invariant holds by
+    * construction. What this adds is a diagnosable failure mode — if a future change ever breaks the "Option is Some
+    * iff errors is empty" invariant, this fails loudly with a message naming the violated contract and the call site,
+    * instead of a bare, context-free `NoSuchElementException`.
+    *
+    * @param context
+    *   short, human-readable description of the call site / invariant, included in the failure message to make
+    *   regressions diagnosable
+    */
+  def getValidated[T](opt: Option[T], errors: Iterable[CompilationError], context: String): T = {
+    require(
+      errors.isEmpty,
+      s"RIDE compiler invariant violated ($context): paired error list is non-empty ($errors) " +
+        s"but the corresponding value was requested as if compilation had succeeded"
+    )
+    opt.getOrElse(
+      throw new IllegalStateException(
+        s"RIDE compiler invariant violated ($context): paired error list is empty, " +
+          s"but the expected compiled value is None"
+      )
+    )
+  }
+
+  /** Variant of [[getValidated]] for the simpler idiom where the same `Option` is checked for emptiness immediately
+    * before being unwrapped (no separate paired error list). Converts a bare `.get` into a diagnosable failure if the
+    * "checked non-empty, then unwrapped" invariant is ever broken by a future change.
+    */
+  def getValidated[T](opt: Option[T], context: String): T =
+    opt.getOrElse(
+      throw new IllegalStateException(
+        s"RIDE compiler invariant violated ($context): expected Some(_) at this point, but got None"
+      )
+    )
+
   def compileWithParseResult(
       input: String,
       offset: LibrariesOffset,
@@ -1117,8 +1172,8 @@ object ExpressionCompiler {
                  else
                    List(
                      Generic(
-                       removedCharPosOpt.get.start,
-                       removedCharPosOpt.get.end,
+                       getValidated(removedCharPosOpt, "compileWithParseResult: removed-char recovery position").start,
+                       getValidated(removedCharPosOpt, "compileWithParseResult: removed-char recovery position").end,
                        "Parsing failed. Some chars was removed as result of recovery process."
                      )
                    ))

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/TypeInferrer.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/TypeInferrer.scala
@@ -98,7 +98,13 @@ object TypeInferrer {
                 case LIST(t: REAL) => Right(UNION(t :: l, None))
                 case _             => Left(err)
               }
-            case _ => ???
+            case other =>
+              throw new IllegalStateException(
+                s"Unreachable: matchTypes fold over a PARAMETERIZEDLIST/UNION accumulated a non-UNION " +
+                  s"intermediate result ($other). The accumulator starts as UNION(List(), None) and every " +
+                  s"branch of this fold either short-circuits with Left or re-wraps in UNION, so it should " +
+                  s"never become anything else."
+              )
           }
         }.flatMap { t =>
           matchTypes(t, innerTypeParam, knownTypes, argTypeStr, matchingTypeStr)
@@ -121,7 +127,13 @@ object TypeInferrer {
           parameterized
             .foldLeft(error) { case (result, nextParameter) =>
               val nonMatchedArgTypes = argType match {
-                case NOTHING            => ???
+                case NOTHING =>
+                  throw new IllegalStateException(
+                    "Unreachable: matchTypes reached the parameterized-union branch with argType = NOTHING. " +
+                      "NOTHING has an empty typeList, so the preceding guard " +
+                      "'concretes >= UNION.create(argType.typeList)' is always true for it and the enclosing " +
+                      "'else' branch should never be entered."
+                  )
                 case UNION(argTypes, _) => UNION(argTypes.filterNot(concretes.typeList.contains))
                 case ANY                => ANY
                 case s: SINGLE          => s

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/Types.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/compiler/Types.scala
@@ -119,7 +119,12 @@ object Types {
             case NOTHING         => List.empty
             case UNION(inner, _) => inner
             case s: REAL         => List(s)
-            case ANY             => ???
+            case ANY             =>
+              throw new IllegalStateException(
+                "Unreachable: UNION.create's inner flatMap encountered ANY, but the enclosing 'if (l.contains(ANY))' " +
+                  "guard above already returns ANY early whenever any element of l is ANY, so this branch's input " +
+                  "list can never contain ANY."
+              )
           }.toList
             .distinct,
           n

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/evaluator/EvaluatorV1.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/evaluator/EvaluatorV1.scala
@@ -71,7 +71,11 @@ class EvaluatorV1[F[_]: Monad, C[_[_]]](implicit ev: Monad[EvalF[F]], ev2: Monad
     evalExpr(cond).flatMap {
       case TRUE  => evalExprWithCtx(ifTrue)
       case FALSE => evalExprWithCtx(ifFalse)
-      case _     => ???
+      case other =>
+        throw new IllegalStateException(
+          s"Unreachable: IF condition evaluated to non-Boolean value $other. " +
+            s"The type checker guarantees IF conditions have type Boolean before evaluation reaches this point."
+        )
     }
 
   private def evalGetter(expr: EXPR, field: String): EvalM[F, C, (EvaluationContext[C, F], EVALUATED)] =

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/evaluator/ctx/impl/dcc/Vals.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/evaluator/ctx/impl/dcc/Vals.scala
@@ -3,7 +3,7 @@ package com.decentralchain.lang.v1.evaluator.ctx.impl.dcc
 import cats.syntax.either.*
 import cats.syntax.functor.*
 import cats.{Eval, Monad}
-import com.decentralchain.lang.ExecutionError
+import com.decentralchain.lang.{CommonError, ExecutionError}
 import com.decentralchain.lang.directives.values.StdLibVersion
 import com.decentralchain.lang.v1.compiler.Terms.*
 import com.decentralchain.lang.v1.compiler.Types.*
@@ -110,8 +110,10 @@ object Vals {
                 case aid: Environment.AssetId => aid.id
               }
             )
-            .map(v => buildAssetInfo(v.get, version): EVALUATED)
-            .map(_.asRight[ExecutionError])
+            .map {
+              case Some(info) => (buildAssetInfo(info, version): EVALUATED).asRight[ExecutionError]
+              case None       => CommonError("Asset info is unavailable in this evaluation context").asLeft[EVALUATED]
+            }
         }
     }
 
@@ -121,8 +123,10 @@ object Vals {
         Eval.later {
           env
             .lastBlockOpt()
-            .map(v => Bindings.buildBlockInfo(v.get, version): EVALUATED)
-            .map(_.asRight[ExecutionError])
+            .map {
+              case Some(info) => (Bindings.buildBlockInfo(info, version): EVALUATED).asRight[ExecutionError]
+              case None => CommonError("Last block info is unavailable in this evaluation context").asLeft[EVALUATED]
+            }
         }
     }
 

--- a/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/parser/Parser.scala
+++ b/packages/ride/lang/shared/src/main/scala/com/decentralchain/lang/v1/parser/Parser.scala
@@ -313,7 +313,7 @@ class Parser(stdLibVersion: StdLibVersion)(implicit offset: LibrariesOffset) {
     def pattern(implicit c: fastparse.P[Any]): P[Pattern] =
       (varDefP ~ comment ~ typesDefP).map { case (v, t) => TypedVar(v, t) } |
         (Index ~ "(" ~ pattern.rep(min = 2, sep = ",") ~/ ")" ~ Index).map(p => TuplePat(p._2, Pos(p._1, p._3))) |
-        (Index ~ anyVarName() ~ "(" ~ (anyVarName() ~ "=" ~ pattern).rep(min = objPatMin, sep = ",") ~ ")" ~ Index)
+        (Index ~ anyVarName() ~ "(" ~ (NoCut(anyVarName()).filter(_.isInstanceOf[VALID[?]]) ~ "=" ~ pattern).rep(min = objPatMin, sep = ",") ~ ")" ~ Index)
           .map(p => ObjPat(p._3.map(kp => (PART.toOption(kp._1).get, kp._2)).toMap, Single(p._2, None), Pos(p._1, p._4))) |
         (Index ~ baseExpr.rep(min = 1, sep = "|") ~ Index).map(p => ConstsPat(p._2, Pos(p._1, p._3)))
 

--- a/packages/ride/lang/tests/src/test/scala/com/decentralchain/lang/parser/ScriptParserTest.scala
+++ b/packages/ride/lang/tests/src/test/scala/com/decentralchain/lang/parser/ScriptParserTest.scala
@@ -894,6 +894,15 @@ class ScriptParserTest extends PropSpec with ScriptGenParser {
     )
   }
 
+  property("object pattern with a reserved keyword as a field name fails to parse cleanly, does not crash") {
+    // Regression test: Parser.scala's object-pattern rule used to extract the field
+    // name via `PART.toOption(kp._1).get`, which threw NoSuchElementException when
+    // `anyVarName()` returned PART.INVALID (i.e. the field name is a keyword like
+    // "if"). This must now surface as an ordinary parse failure, not a raw exception.
+    noException should be thrownBy parseE("match tx { case Foo(if = 1) => 1 }", version = V8)
+    parseE("match tx { case Foo(if = 1) => 1 }", version = V8) shouldBe a[Left[?, ?]]
+  }
+
   ignore("pattern matching with invalid case - expression in variable definition") {
     parse("match tx { case 1 + 1 => 1 } ") shouldBe MATCH(
       AnyPos,

--- a/packages/ride/project/build.properties
+++ b/packages/ride/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.11
+sbt.version=1.12.13


### PR DESCRIPTION
## Summary
- Rust (blockchain-postgres-sync): panic fix, dependency bumps, parameterized test SQL, pinned compose image digest.
- RIDE (packages/ride): fragile `.get` call sites replaced with validated helpers, bare `???` stubs converted to descriptive exceptions, two real crash-site fixes (Parser.scala object-pattern field name, Vals.scala unguarded Option.get), coverage-tooling limitations documented in KNOWN_ISSUES.md.
- Frontend: JWT fail-open fix, tightened `any` types, removed an injection habit.

## Test plan
- [x] `cargo build`/`cargo test` (103 unit + 9 consumer_repo via testcontainers + 3 db_integration + proptest) — 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo audit` — 355 crates, 0 vulnerabilities
- [x] `sbt lang-tests/test` — 1313/1313 passing (2 shifted, 0 failed, 3 ignored pre-existing)
- [x] `sbt lang/compile` / `repl/compile` — clean
- [ ] CI required checks (ci, CodeQL, Trivy) — pending on this PR