### PR TITLE
fix: e2e client-side rate-limit bypass header injection

### DIFF
--- a/packages/e2e-blockchain/src/setup/env.ts
+++ b/packages/e2e-blockchain/src/setup/env.ts
@@ -32,3 +32,31 @@ export const API_KEY = process.env.DCC_TEST_API_KEY ?? process.env.DCC_API_KEY ?
 
 /** Node wallet address (for /transactions/sign — node signs with its own key) */
 export const NODE_ADDRESS = process.env.DCC_TEST_NODE_ADDRESS ?? process.env.DCC_NODE_ADDRESS ?? '';
+
+/**
+ * Caddy's rate limiter (infra/.github/workflows/update-caddy.yml) throttles
+ * /transactions/broadcast to 50/min per IP. Running ~20+ spec files
+ * concurrently, each funding its own test accounts via one broadcast apiece,
+ * legitimately exceeds that on its own. DCC_TEST_E2E_BYPASS_KEY (set only in
+ * admin-e2e.yml from the E2E_RATE_LIMIT_BYPASS_KEY secret) lets our own CI
+ * traffic skip rate limiting via a secret header Caddy checks for an exact
+ * match -- anyone without the real secret value still gets fully rate
+ * limited. Scoped to *.decentralchain.io only, and monkey-patches global
+ * fetch here (the test suite's own setup file) rather than any published SDK
+ * package, so this has zero effect on real dApp developers using those SDKs.
+ */
+const E2E_BYPASS_KEY = process.env.DCC_TEST_E2E_BYPASS_KEY;
+if (E2E_BYPASS_KEY) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (/^https?:\/\/([a-z0-9-]+\.)?decentralchain\.io\//i.test(url)) {
+      const headers = new Headers(
+        init?.headers ?? (input instanceof Request ? input.headers : undefined),
+      );
+      headers.set('X-E2E-Bypass', E2E_BYPASS_KEY);
+      return originalFetch(input, { ...init, headers });
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+}


### PR DESCRIPTION
## Summary
- Companion to `infra` PR #19 (Caddy secret-gated rate-limit bypass + `admin-e2e.yml` wiring).
- Adds a global `fetch` wrapper in `packages/e2e-blockchain/src/setup/env.ts` (vitest `setupFiles` entry) that attaches an `X-E2E-Bypass` header, read from `DCC_TEST_E2E_BYPASS_KEY`, to outgoing requests targeting `*.decentralchain.io`.

## Why
Testnet's Caddy now rate-limits `/transactions/broadcast` at 50/min per IP. The full e2e suite legitimately exceeds this: ~20+ spec files each fund their own test accounts via one broadcast apiece. Confirmed via a real full-suite run: `55 failed | 87 passed | 20 skipped (162)`, all failures `HTTP 429`.

## Design
- Scoped entirely to this package's own test setup file, not any published SDK package (`node-api`, `transactions`) that real dApp developers depend on — zero effect outside the e2e test process.
- Only activates when `DCC_TEST_E2E_BYPASS_KEY` is set (only true in CI via the `E2E_RATE_LIMIT_BYPASS_KEY` secret) and only targets `*.decentralchain.io` — never attaches the header to unrelated third-party requests.

## Test plan
- [ ] Merge alongside infra PR #19
- [ ] Run `update-caddy.yml` to deploy the bypass-aware Caddyfile to testnet
- [ ] Re-run `admin-e2e.yml` with `suite=full` and confirm 429 failures are resolved