### PR TITLE
ci: fix publish-maven reusable-workflow startup_failure (grant id-token/attestations)

### DIFF
--- a/.github/workflows/publish-protobuf-schemas.yml
+++ b/.github/workflows/publish-protobuf-schemas.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write        # reusable _publish-maven.yml requests these (SBOM + SLSA build-provenance);
+  attestations: write    # a caller must grant >= the reusable job's permissions, else GitHub startup-fails
 
 concurrency:
   group: publish-protobuf-schemas


### PR DESCRIPTION
Caller granted only contents:read; reusable _publish-maven.yml job requests id-token/attestations (SBOM + build-provenance) -> GitHub startup_failure on every publish since #53. Grant the required permissions. Unblocks protobuf-schemas 1.6.4 publish (T2 HotStuff).