### PR TITLE
fix(protobuf-schemas): stop publish hang + auto-publish to Central

### DIFF
--- a/packages/sdk/protobuf-schemas/pom.xml
+++ b/packages/sdk/protobuf-schemas/pom.xml
@@ -340,7 +340,12 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <deploymentName>${project.artifactId}-${project.version}</deploymentName>
-                            <autoPublish>false</autoPublish>
+                            <autoPublish>true</autoPublish>
+                            <!-- Return after upload; the Central Portal validates + auto-publishes async.
+                                 Without a bounded wait the plugin polled for a deployment state that never
+                                 arrived and hung until the 30-minute job timeout (the prior publish failures,
+                                 10x "empty comment" poll warnings). -->
+                            <waitUntil>uploaded</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
central-publishing-maven-plugin polled for a deployment state that never arrived (autoPublish=false, no waitUntil) -> 30m timeout on every publish since #53. waitUntil=uploaded + autoPublish=true. Unblocks 1.6.4.