### PR TITLE
fix(cubensis-connect): point testnet matcher at testnet-matcher.decentralchain.io

### DIFF
--- a/apps/cubensis-connect/src/constants.ts
+++ b/apps/cubensis-connect/src/constants.ts
@@ -19,7 +19,7 @@ export const NETWORK_CONFIG: Record<
   }
 > = {
   [NetworkName.Testnet]: {
-    matcherBaseUrl: 'https://matcher.decentralchain.io/',
+    matcherBaseUrl: 'https://testnet-matcher.decentralchain.io/',
     name: NetworkName.Testnet,
     networkCode: '!',
     nodeBaseUrl: 'https://testnet-node.decentralchain.io/',


### PR DESCRIPTION
The testnet wallet's matcherBaseUrl was https://matcher.decentralchain.io/ — a dead host (162.0.224.184, connection refused). Live testnet matcher is testnet-matcher.decentralchain.io (verified 200 + matcherPublicKey). nodeBaseUrl was already correct; matcher URL was missed. Mainnet/stagenet unchanged. Verified against live DNS + endpoints.